### PR TITLE
[FIX] gorm ignore zero value("") when updating

### DIFF
--- a/db/mysql/dao/gateway.go
+++ b/db/mysql/dao/gateway.go
@@ -168,10 +168,7 @@ func (h *HTTPRuleDaoImpl) UpdateModel(mo model.Interface) error {
 	if !ok {
 		return fmt.Errorf("Failed to convert %s to *model.HTTPRule", reflect.TypeOf(mo).String())
 	}
-
-	return h.DB.Table(hr.TableName()).
-		Where("uuid = ?", hr.UUID).
-		Update(hr).Error
+	return h.DB.Save(hr).Error
 }
 
 // GetHTTPRuleByID gets a HTTPRule based on uuid


### PR DESCRIPTION
Since the update method of gorm ignores the zero value, the path of "" will be ignored when updating the http rule.