### PR TITLE
[REV] move ForceSSLRedirect from servers.tmpl to the gateway controller

### DIFF
--- a/gateway/controller/openresty/service.go
+++ b/gateway/controller/openresty/service.go
@@ -215,9 +215,9 @@ func (o *OrService) persistUpstreams(pools []*v1.Pool, tmpl string, path string,
 func getNgxServer(conf *v1.Config) (l7srv []*model.Server, l4srv []*model.Server) {
 	for _, vs := range conf.L7VS {
 		server := &model.Server{
-			Listen:           strings.Join(vs.Listening, " "),
-			ServerName:       strings.Replace(vs.ServerName, "tls", "", 1),
-			ForceSSLRedirect: vs.ForceSSLRedirect,
+			Listen:     strings.Join(vs.Listening, " "),
+			ServerName: strings.Replace(vs.ServerName, "tls", "", 1),
+			// ForceSSLRedirect: vs.ForceSSLRedirect,
 			OptionValue: map[string]string{
 				"tenant_id":  vs.Namespace,
 				"service_id": vs.ServiceID,
@@ -227,9 +227,6 @@ func getNgxServer(conf *v1.Config) (l7srv []*model.Server, l4srv []*model.Server
 		if vs.SSLCert != nil {
 			server.SSLCertificate = vs.SSLCert.CertificatePem
 			server.SSLCertificateKey = vs.SSLCert.CertificatePem
-			if vs.ForceSSLRedirect {
-
-			}
 		}
 		for _, loc := range vs.Locations {
 			location := &model.Location{
@@ -240,6 +237,7 @@ func getNgxServer(conf *v1.Config) (l7srv []*model.Server, l4srv []*model.Server
 				Proxy:            loc.Proxy,
 				Rewrite:          loc.Rewrite,
 				PathRewrite:      false,
+				DisableProxyPass: loc.DisableProxyPass,
 			}
 			server.Locations = append(server.Locations, location)
 		}

--- a/gateway/v1/location.go
+++ b/gateway/v1/location.go
@@ -45,7 +45,8 @@ type Location struct {
 	// Proxy contains information about timeouts and buffer sizes
 	// to be used in connections against endpoints
 	// +optional
-	Proxy proxy.Config `json:"proxy,omitempty"`
+	Proxy            proxy.Config `json:"proxy,omitempty"`
+	DisableProxyPass bool
 }
 
 // Condition is the condition that the traffic can reach the specified backend

--- a/hack/contrib/docker/gateway/nginxtmp/servers.tmpl
+++ b/hack/contrib/docker/gateway/nginxtmp/servers.tmpl
@@ -1,19 +1,5 @@
 {{ $http_port := .Set.ListenPorts.HTTP }}
 {{ range $srv := .Servers }}
-{{ if $srv.ForceSSLRedirect }}
-server {
-    listen {{ $http_port }};
-    {{ if $srv.ServerName }}server_name    {{$srv.ServerName}};{{end}}
-    {{ range $loc := $srv.Locations }}
-    location {{$loc.Path}} {
-        rewrite ^ https://$http_host$request_uri? permanent;
-        {{ if $loc.DisableAccessLog }}
-        access_log off;
-        {{ end }}
-    }
-    {{ end }}
-}
-{{ end }}
 server {
     {{ if $srv.Listen }}listen    {{$srv.Listen}};{{ end }}
     {{ if $srv.Root }}root    {{$srv.Root}};{{ end }}


### PR DESCRIPTION
Move the logic of ForceSSLRedirect from servers.tmpl to the gateway controller.
The purpose of this is to merge the http location set by the user with the http location generated by ForceSSLRedirect.
