### PR TITLE
[FIX] No updates to the running http endpoints

### DIFF
--- a/gateway/controller/controller.go
+++ b/gateway/controller/controller.go
@@ -34,7 +34,7 @@ import (
 	"github.com/goodrain/rainbond/gateway/controller/openresty"
 	"github.com/goodrain/rainbond/gateway/metric"
 	"github.com/goodrain/rainbond/gateway/store"
-	v1 "github.com/goodrain/rainbond/gateway/v1"
+	"github.com/goodrain/rainbond/gateway/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/ingress-nginx/task"
@@ -258,8 +258,11 @@ func (gwc *GWController) initRbdEndpoints(errCh chan<- error) {
 // updateRbdPools updates rainbond pools
 func (gwc *GWController) updateRbdPools(edps map[string][]string) {
 	h, t := gwc.getRbdPools(edps)
-	//merge app pool
-	h = append(h, gwc.rhp...)
+
+	if h != nil {
+		//merge app pool
+		h = append(h, gwc.rhp...)
+	}
 	if err := gwc.GWS.UpdatePools(h, t); err != nil {
 		logrus.Errorf("update rainbond pools failure %s", err.Error())
 	}
@@ -313,9 +316,31 @@ func (gwc *GWController) getRbdPools(edps map[string][]string) ([]*v1.Pool, []*v
 		}
 	}
 
-	gwc.rrbdp = hpools
+	if !rrbdpEqual(hpools, gwc.rrbdp) {
+		gwc.rrbdp = hpools
+		return hpools, tpools
+	}
 
-	return hpools, tpools
+	return nil, tpools
+}
+
+func rrbdpEqual(a []*v1.Pool, b []*v1.Pool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for _, ap := range a {
+		flag := false
+		for _, bp := range b {
+			if ap.Equals(bp) {
+				flag = true
+				break
+			}
+		}
+		if !flag {
+			return false
+		}
+	}
+	return true
 }
 
 // listRbdEndpoints lists rainbond endpoints form etcd

--- a/gateway/controller/controller.go
+++ b/gateway/controller/controller.go
@@ -154,6 +154,7 @@ func (gwc *GWController) syncGateway(key interface{}) error {
 		logrus.Info("No need to update running configuration.")
 		// refresh http pools dynamically
 		httpPools = append(httpPools, gwc.rrbdp...)
+		gwc.rhp = httpPools
 		gwc.refreshPools(httpPools)
 		return nil
 	}

--- a/gateway/controller/openresty/service.go
+++ b/gateway/controller/openresty/service.go
@@ -261,6 +261,9 @@ func getNgxServer(conf *v1.Config) (l7srv []*model.Server, l4srv []*model.Server
 
 // UpdatePools updates http upstreams dynamically.
 func (o *OrService) UpdatePools(hpools []*v1.Pool, tpools []*v1.Pool) error {
+	var lock sync.Mutex
+	lock.Lock()
+	defer lock.Unlock()
 	if len(tpools) > 0 {
 		err := o.persistUpstreams(tpools, "upstreams-tcp.tmpl", "/run/nginx/rainbond/stream",
 			"upstream.default.tcp.conf")


### PR DESCRIPTION
修复两个问题
1. 没有更新http endpoints缓存
2. k8s 和 etcd 并发的去更新 nginx 中的 backends(upstreams), 导致数据不对. 加了互斥量对这个动作进行同步.

这两个问题会导致服务更新了, 但是 nginx 中是 backends 没有更新, 导致服务无法访问