### PR TITLE
[FIX] nil pointer dereference

### DIFF
--- a/node/nodem/envoy/server_v2.go
+++ b/node/nodem/envoy/server_v2.go
@@ -305,6 +305,7 @@ func (d *DiscoverServerManager) Start(errch chan error) error {
 		lis, err := net.Listen("tcp", d.conf.GrpcAPIAddr)
 		if err != nil {
 			errch <- err
+			return
 		}
 		if err = d.grpcServer.Serve(lis); err != nil {
 			errch <- err


### PR DESCRIPTION
panic: invalid memory address or nil pointer dereference