### PR TITLE
[FIX] wrong cluster status

### DIFF
--- a/grctl/cmd/node.go
+++ b/grctl/cmd/node.go
@@ -150,7 +150,12 @@ func getStatusShow(v *client.HostNode) (status string) {
 		nss.message = append(nss.message, "unhealth")
 		nss.color = color.FgRed
 	}
-	return nss.String()
+
+	result := nss.String() 
+	if strings.Contains(result, "unknown") {
+		result = "unknown"
+	}
+	return result
 }
 func handleStatus(serviceTable *termtables.Table, v *client.HostNode) {
 	serviceTable.AddRow(v.ID, v.InternalIP, v.HostName, v.Role.String(), getStatusShow(v))


### PR DESCRIPTION
If the status is unknown, then there is no statement of healthy or unhealthy.