### PR TITLE
[FIX] fix issue(#338) bug, modify tenant service env max size to 1024

### DIFF
--- a/db/model/tenant.go
+++ b/db/model/tenant.go
@@ -276,7 +276,7 @@ type TenantServiceEnvVar struct {
 	ContainerPort int    `gorm:"column:container_port" validate:"container_port|numeric_between:1,65535" json:"container_port"`
 	Name          string `gorm:"column:name;size:100" validate:"name" json:"name"`
 	AttrName      string `gorm:"column:attr_name" validate:"env_name|required" json:"attr_name"`
-	AttrValue     string `gorm:"column:attr_value" validate:"env_value|required" json:"attr_value"`
+	AttrValue     string `gorm:"column:attr_value;size:1024" validate:"env_value|required" json:"attr_value"`
 	IsChange      bool   `gorm:"column:is_change" validate:"is_change|bool" json:"is_change"`
 	Scope         string `gorm:"column:scope;default:'outer'" validate:"scope|in:outer,inner,both" json:"scope"`
 }

--- a/db/mysql/mysql.go
+++ b/db/mysql/mysql.go
@@ -165,4 +165,9 @@ func (m *Manager) CheckTable() {
 	})
 }
 
-func (m *Manager) patchTable() {}
+func (m *Manager) patchTable() {
+	//modify tenant service env max size to 1024
+	if err := m.db.Exec("alter table tenant_services_envs modify column attr_value varchar(1024);").Error; err != nil {
+		logrus.Errorf("alter table tenant_services_envs error %s", err.Error())
+	}
+}


### PR DESCRIPTION
修改数据库中表的字段，将其支持长度修改为1024