### PR TITLE
[fix] resolve node install no log

### DIFF
--- a/event/manager.go
+++ b/event/manager.go
@@ -49,6 +49,8 @@ type Manager interface {
 	Close() error
 	ReleaseLogger(Logger)
 }
+
+// EventConfig event config struct
 type EventConfig struct {
 	EventLogServers []string
 	DiscoverAddress []string
@@ -263,6 +265,7 @@ func (m *manager) getLBChan() chan []byte {
 		m.qos = atomic.AddInt32(&(m.qos), 1)
 		server := m.eventServer[index]
 		if _, ok := m.abnormalServer[server]; ok {
+			logrus.Warnf("server[%s] is abnormal, skip it", server)
 			continue
 		}
 		if h, ok := m.handles[server]; ok {
@@ -431,6 +434,7 @@ func (l *loggerWriter) Write(b []byte) (n int, err error) {
 		if l.fmt != "" {
 			message = fmt.Sprintf(l.fmt, message)
 		}
+		logrus.Debugf("step: %s, level: %s;write message : %v", l.step, l.level, message)
 		l.l.send(message, map[string]string{"step": l.step, "level": l.level})
 	}
 	return len(b), nil

--- a/node/core/service/node_service.go
+++ b/node/core/service/node_service.go
@@ -52,6 +52,7 @@ type NodeService struct {
 func CreateNodeService(c *option.Conf, nodecluster *node.Cluster, kubecli kubecache.KubeClient) *NodeService {
 	if err := event.NewManager(event.EventConfig{
 		DiscoverAddress: c.Etcd.Endpoints,
+		EventLogServers: c.EventLogServer,
 	}); err != nil {
 		logrus.Errorf("create event manager faliure")
 	}
@@ -159,11 +160,6 @@ func (n *NodeService) AsynchronousInstall(node *client.HostNode, eventID string)
 		logrus.Error("write hosts file error ", err.Error())
 		return
 	}
-	if err := event.NewManager(event.EventConfig{
-		DiscoverAddress: n.c.Etcd.Endpoints,
-	}); err != nil {
-		logrus.Errorf("create event manager faliure")
-	}
 	// start add node script
 	logrus.Infof("Begin install node %s", node.ID)
 	// write log to event log
@@ -179,9 +175,10 @@ func (n *NodeService) AsynchronousInstall(node *client.HostNode, eventID string)
 		Stdout:     logger.GetWriter("node-install", "info"),
 		Stderr:     logger.GetWriter("node-install", "err"),
 	}
+
 	err = ansibleUtil.RunNodeInstallCmd(option)
 	if err != nil {
-		logrus.Error("Error executing shell script", err)
+		logrus.Error("Error executing shell script : ", err)
 		node.Status = client.InstallFailed
 		node.NodeStatus.Status = client.InstallFailed
 		n.nodecluster.UpdateNode(node)

--- a/node/core/service/node_service_test.go
+++ b/node/core/service/node_service_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/goodrain/rainbond/cmd/node/option"
+	"github.com/goodrain/rainbond/event"
+
+	etcdClient "github.com/coreos/etcd/clientv3"
+	"github.com/goodrain/rainbond/node/core/store"
+	"github.com/goodrain/rainbond/node/masterserver"
+	"github.com/goodrain/rainbond/node/masterserver/node"
+	"github.com/goodrain/rainbond/node/nodem/client"
+)
+
+func TestAsynchronousInstall(t *testing.T) {
+	config := &option.Conf{
+		Etcd:           etcdClient.Config{Endpoints: []string{"192.168.195.1:2379"}},
+		EventLogServer: []string{"192.168.195.1:6366"},
+	}
+
+	store.NewClient(config)
+	// node *client.HostNode, eventID string
+	eventID := "fanyangyang"
+	// nodemanager := nodem.NewNodeManager(&option.Conf{})
+	currentNode := client.HostNode{
+		ID:         "123",
+		Role:       []string{"manage"},
+		InternalIP: "127.0.0.1",
+		RootPass:   "password",
+	}
+	cluster := node.CreateCluster(nil, &currentNode, nil)
+	cluster.CacheNode(&currentNode)
+	ms := &masterserver.MasterServer{Cluster: cluster}
+	nodeService := CreateNodeService(config, ms.Cluster, nil)
+	nodeService.AsynchronousInstall(&currentNode, eventID)
+	event.GetManager().Close()
+}


### PR DESCRIPTION
修改node/core/service/node_service.go中对eventLog Manager的创建传参，添加EventLogServers参数。

在创建eventLog Manager过程中，需要其他服务组件进行日志的接收，所以需要EventLogServers参数的支持。