### PR TITLE
[FIX] confused nginx upstream

### DIFF
--- a/cmd/gateway/server/server.go
+++ b/cmd/gateway/server/server.go
@@ -100,7 +100,7 @@ func Run(s *option.GWServer) error {
 	logrus.Info("RBD app gateway start success!")
 
 	term := make(chan os.Signal)
-	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(term, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	select {
 	case <-term:
 		logrus.Warn("Received SIGTERM, exiting gracefully...")

--- a/gateway/controller/openresty/template/templete_manage.go
+++ b/gateway/controller/openresty/template/templete_manage.go
@@ -243,7 +243,8 @@ func (n *NginxConfigFileTemplete) WriteServer(c option.Config, configtype, tenan
 	}
 	n.writeLocks[tenant].Lock()
 	defer n.writeLocks[tenant].Unlock()
-	serverConfigFile := path.Join(n.configFileDirPath, configtype, tenant, "servers.conf")
+	filename := fmt.Sprintf("%s_servers.conf", tenant)
+	serverConfigFile := path.Join(n.configFileDirPath, configtype, tenant, filename)
 	first := true
 	if servers == nil || len(servers) < 1 {
 		logrus.Warnf("%s proxy is empty, nginx server[%s] will clean up", tenant, serverConfigFile)

--- a/hack/contrib/docker/gateway/nginxtmp/nginx.tmpl
+++ b/hack/contrib/docker/gateway/nginxtmp/nginx.tmpl
@@ -160,10 +160,10 @@ http {
             }
         }
     }
-    include http/*/*.conf;
+    include http/*/*_servers.conf;
 }
 
 stream {
     include stream/*/upstreams.conf;
-    include stream/*/servers.conf;
+    include stream/*/*_servers.conf;
 }


### PR DESCRIPTION
问题: 当nginx服务器的文件名相同时，且服务器里的内容的行数也一样时，有几率造成access_by_lua_block执行其他服务器里的代码
解决方法: 为每个租户生成不一样的server文件