### PR TITLE
delete all keys in unkown node

### DIFF
--- a/node/nodem/client/cluster_client.go
+++ b/node/nodem/client/cluster_client.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -32,6 +33,9 @@ import (
 	"github.com/goodrain/rainbond/node/core/config"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
+
+// RainbondEndpointPrefix is the prefix of the key of the rainbond endpoints in etcd
+const RainbondEndpointPrefix = "/rainbond/endpoint"
 
 //ClusterClient ClusterClient
 type ClusterClient interface {
@@ -102,7 +106,7 @@ func (e *etcdClusterClient) GetOptions() *option.Conf {
 }
 
 func (e *etcdClusterClient) GetEndpoints(key string) (result []string) {
-	key = "/rainbond/endpoint/" + key
+	key = path.Join(RainbondEndpointPrefix, key)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	resp, err := e.conf.EtcdCli.Get(ctx, key, clientv3.WithPrefix())
@@ -124,7 +128,7 @@ func (e *etcdClusterClient) GetEndpoints(key string) (result []string) {
 }
 
 func (e *etcdClusterClient) SetEndpoints(key string, value []string) {
-	key = "/rainbond/endpoint/" + key
+	key = path.Join(RainbondEndpointPrefix, key)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	jsonStr, err := json.Marshal(value)
@@ -139,7 +143,7 @@ func (e *etcdClusterClient) SetEndpoints(key string, value []string) {
 }
 
 func (e *etcdClusterClient) DelEndpoints(key string) {
-	key = "/rainbond/endpoint/" + key
+	key = path.Join(RainbondEndpointPrefix, key)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	_, err := e.conf.EtcdCli.Delete(ctx, key)

--- a/node/nodem/client/cluster_client_test.go
+++ b/node/nodem/client/cluster_client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/goodrain/rainbond/cmd/node/option"
+	"github.com/goodrain/rainbond/node/core/store"
 	"github.com/goodrain/rainbond/util"
 	"testing"
 	"time"
@@ -103,4 +104,27 @@ func TestEtcdClusterClient_GetEndpoints(t *testing.T) {
 			t.Fatalf("Can not find \"%s\" in %v", tc, edps)
 		}
 	}
+}
+
+func TestEtcdClusterClient_ListEndpointKeys(t *testing.T) {
+	cfg := &option.Conf{
+		Etcd: clientv3.Config{
+			Endpoints:   []string{"192.168.3.3:2379"},
+			DialTimeout: 5 * time.Second,
+		},
+	}
+
+	if err := store.NewClient(cfg); err != nil {
+		t.Fatalf("error create etcd client: %v", err)
+	}
+
+	hostNode := HostNode{
+		InternalIP: "192.168.2.76",
+	}
+
+	keys, err := hostNode.listEndpointKeys()
+	if err != nil {
+		t.Errorf("unexperted error: %v", err)
+	}
+	t.Logf("keys: %#v", keys)
 }

--- a/node/nodem/client/node.go
+++ b/node/nodem/client/node.go
@@ -499,9 +499,12 @@ func (n *HostNode) DeleteNode() (*client.DeleteResponse, error) {
 
 // DelEndpoints -
 func (n *HostNode) DelEndpoints() {
-	keys := n.listEndpointKeys()
+	keys, err := n.listEndpointKeys()
+	if err != nil {
+		logrus.Warningf("error deleting endpoints: %v", err)
+		return
+	}
 	for _, key := range keys {
-		key = key + n.InternalIP
 		res, err := store.DefalutClient.Delete(key)
 		if err != nil {
 			logrus.Warnf("key: %s; error delete endpoints: %v", key, err)
@@ -510,11 +513,19 @@ func (n *HostNode) DelEndpoints() {
 	}
 }
 
-func (n *HostNode) listEndpointKeys() []string {
-	// TODO: need improvement, not hard code
-	return []string{
-		"/rainbond/endpoint/APISERVER_ENDPOINTS/",
-		"/rainbond/endpoint/HUB_ENDPOINTS/",
-		"/rainbond/endpoint/REPO_ENDPOINTS/",
+func (n *HostNode) listEndpointKeys() ([]string, error) {
+	resp, err := store.DefalutClient.Get(RainbondEndpointPrefix, client.WithPrefix())
+	if err != nil {
+		return nil, fmt.Errorf("prefix: %s; error list rainbond endpoint keys by prefix: %v", RainbondEndpointPrefix, err)
 	}
+
+	var res []string
+	for _, kv := range resp.Kvs {
+		key := string(kv.Key)
+		if strings.Contains(key, n.InternalIP) {
+			res = append(res, key)
+		}
+	}
+
+	return res, nil
 }


### PR DESCRIPTION
当节点状态为unkown时, 把它在etcd中相关的数据(/rainbond/endpint)下的数据删除掉.