### PR TITLE
[FIX] node uuid is null

### DIFF
--- a/util/ansible/node.go
+++ b/util/ansible/node.go
@@ -57,7 +57,7 @@ func RunNodeInstallCmd(option NodeInstallOption) (err error) {
 	if err := preCheckNodeInstall(&option); err != nil {
 		return err
 	}
-	line := fmt.Sprintf("%s -r %s -i %s -t %s -k %s -u %s",
+	line := fmt.Sprintf("'%s' -r '%s' -i '%s' -t '%s' -k '%s' -u '%s'",
 		installNodeShellPath, option.HostRole, option.InternalIP, option.linkModel, option.loginValue, option.NodeID)
 	cmd := exec.Command("bash", "-c", line)
 	cmd.Stdin = option.Stdin

--- a/util/ansible/node_test.go
+++ b/util/ansible/node_test.go
@@ -1,0 +1,32 @@
+package ansible
+
+import (
+	"testing"
+)
+
+func TestPreCheckNodeInstall(t *testing.T) {
+	tests := []struct {
+		name    string
+		opt     *NodeInstallOption
+		wanterr bool
+	}{
+		{
+			name:    "empty node id",
+			opt:     &NodeInstallOption{
+				HostRole: "host role",
+				InternalIP: "192.168.1.1",
+				RootPass: "root pass",
+			},
+			wanterr: true,
+		},
+	}
+
+	for idx := range tests {
+		tc := tests[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			if err := preCheckNodeInstall(tc.opt); (err != nil) != tc.wanterr {
+				t.Errorf("want error: %v, but got %v", tc.wanterr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
如果传入到 node.sh 的参数有空格, 这会引发此报错, 如下:

```
./node.sh -r 'aaa bbb' -i 111 -t aaa -k 1 23 -u 123
node uuid is null
```

解决: 为没个参数都加上一个单引号