### PR TITLE
fix bugs issue/609

### DIFF
--- a/api/handler/gateway_action.go
+++ b/api/handler/gateway_action.go
@@ -652,6 +652,21 @@ func (g *GatewayAction) UpdCertificate(req *apimodel.UpdCertificateReq) error {
 		return fmt.Errorf(msg, err)
 	}
 
+	if cert == nil {
+		// cert do not exists in region db, create it
+		cert = &model.Certificate{
+			UUID:            req.CertificateID,
+			CertificateName: req.CertificateName,
+			Certificate:     req.Certificate,
+			PrivateKey:      req.PrivateKey,
+		}
+		if err := db.GetManager().CertificateDao().AddModel(cert); err != nil {
+			msg := "update cert error :%s"
+			return fmt.Errorf(msg, err.Error())
+		}
+		return nil
+	}
+
 	cert.CertificateName = req.CertificateName
 	cert.Certificate = req.Certificate
 	cert.PrivateKey = req.PrivateKey


### PR DESCRIPTION
如果证书没有被使用，则不会被保存在数据中心的数据库中，导致在更新时出现空指针的错误

这里将更新进行修正，如果发现没有这条记录，则尝试着创建该证书记录到数据库中

不会影响其他的逻辑