### PR TITLE
pod template use rbd-dns config

### DIFF
--- a/cmd/worker/option/option.go
+++ b/cmd/worker/option/option.go
@@ -49,6 +49,8 @@ type Config struct {
 	KubeClient              *kubernetes.Clientset
 	LeaderElectionNamespace string
 	LeaderElectionIdentity  string
+	RBDNamespace            string
+	RBDDNSName              string
 }
 
 //Worker  worker server
@@ -84,6 +86,8 @@ func (a *Worker) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.NodeAPI, "node-api", "http://172.30.42.1:6100", "node discover api, node docker endpoints")
 	flag.StringVar(&a.LeaderElectionNamespace, "leader-election-namespace", "rainbond", "Namespace where this attacher runs.")
 	flag.StringVar(&a.LeaderElectionIdentity, "leader-election-identity", "", "Unique idenity of this attcher. Typically name of the pod where the attacher runs.")
+	flag.StringVar(&a.RBDNamespace, "rbd-system-namespace", "rbd-system", "rbd components kubernetes namespace")
+	flag.StringVar(&a.RBDDNSName, "rbd-dns", "rbd-dns", "rbd dns endpoint name")
 }
 
 //SetLog 设置log

--- a/cmd/worker/server/server.go
+++ b/cmd/worker/server/server.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/eapache/channels"
-	kubeaggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	kubeaggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	"github.com/goodrain/rainbond/cmd/worker/option"
 	"github.com/goodrain/rainbond/db"
@@ -101,7 +101,7 @@ func Run(s *option.Worker) error {
 	}
 
 	//step 4: create controller manager
-	controllerManager := controller.NewManager(cachestore, clientset)
+	controllerManager := controller.NewManager(cachestore, clientset, s.Config.RBDNamespace, s.Config.RBDDNSName)
 	defer controllerManager.Stop()
 
 	//step 5 : start runtime master

--- a/worker/appm/controller/controller.go
+++ b/worker/appm/controller/controller.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/goodrain/rainbond/util"
 	"github.com/goodrain/rainbond/worker/appm/store"
-	"github.com/goodrain/rainbond/worker/appm/types/v1"
+	v1 "github.com/goodrain/rainbond/worker/appm/types/v1"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/worker/appm/controller/controller.go
+++ b/worker/appm/controller/controller.go
@@ -66,7 +66,7 @@ var TypeControllerRefreshHPA TypeController = "refreshhpa"
 type Manager struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
-	client       *kubernetes.Clientset
+	client       kubernetes.Interface
 	rbdNamespace string
 	rbdDNSName   string
 	controllers  map[string]Controller

--- a/worker/appm/controller/controller.go
+++ b/worker/appm/controller/controller.go
@@ -64,23 +64,27 @@ var TypeControllerRefreshHPA TypeController = "refreshhpa"
 
 //Manager controller manager
 type Manager struct {
-	ctx         context.Context
-	cancel      context.CancelFunc
-	client      *kubernetes.Clientset
-	controllers map[string]Controller
-	store       store.Storer
-	lock        sync.Mutex
+	ctx          context.Context
+	cancel       context.CancelFunc
+	client       *kubernetes.Clientset
+	rbdNamespace string
+	rbdDNSName   string
+	controllers  map[string]Controller
+	store        store.Storer
+	lock         sync.Mutex
 }
 
 //NewManager new manager
-func NewManager(store store.Storer, client *kubernetes.Clientset) *Manager {
+func NewManager(store store.Storer, client *kubernetes.Clientset, rbdNamespace, rbdDNSName string) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Manager{
-		ctx:         ctx,
-		cancel:      cancel,
-		client:      client,
-		controllers: make(map[string]Controller),
-		store:       store,
+		ctx:          ctx,
+		cancel:       cancel,
+		client:       client,
+		controllers:  make(map[string]Controller),
+		store:        store,
+		rbdNamespace: rbdNamespace,
+		rbdDNSName:   rbdDNSName,
 	}
 }
 

--- a/worker/appm/controller/start.go
+++ b/worker/appm/controller/start.go
@@ -111,7 +111,7 @@ func (s *startController) startOne(app v1.AppService) error {
 	}
 	//step 2: create statefulset or deployment
 	if statefulset := app.GetStatefulSet(); statefulset != nil {
-		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, statefulset.Namespace)
+		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, statefulset.Namespace, s.manager.rbdNamespace, s.manager.rbdDNSName)
 		if err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ func (s *startController) startOne(app v1.AppService) error {
 		}
 	}
 	if deployment := app.GetDeployment(); deployment != nil {
-		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, deployment.Namespace)
+		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, deployment.Namespace, s.manager.rbdNamespace, s.manager.rbdDNSName)
 		if err != nil {
 			return err
 		}

--- a/worker/appm/controller/start.go
+++ b/worker/appm/controller/start.go
@@ -109,26 +109,26 @@ func (s *startController) startOne(app v1.AppService) error {
 			}
 		}
 	}
+	// before create app, prepare poddnsconfig
+	podDNSConfig := workerutil.MakePodDNSConfig(s.manager.client, app.TenantID, s.manager.rbdNamespace, s.manager.rbdDNSName)
 	//step 2: create statefulset or deployment
 	if statefulset := app.GetStatefulSet(); statefulset != nil {
-		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, statefulset.Namespace, s.manager.rbdNamespace, s.manager.rbdDNSName)
-		if err != nil {
-			return err
+		if podDNSConfig != nil {
+			statefulset.Spec.Template.Spec.DNSConfig = podDNSConfig
+			statefulset.Spec.Template.Spec.DNSPolicy = "None"
 		}
-		statefulset.Spec.Template.Spec.DNSConfig = podDNSConfig
-		statefulset.Spec.Template.Spec.DNSPolicy = "None"
+
 		_, err = s.manager.client.AppsV1().StatefulSets(app.TenantID).Create(statefulset)
 		if err != nil {
 			return fmt.Errorf("create statefulset failure:%s", err.Error())
 		}
 	}
 	if deployment := app.GetDeployment(); deployment != nil {
-		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, deployment.Namespace, s.manager.rbdNamespace, s.manager.rbdDNSName)
-		if err != nil {
-			return err
+		if podDNSConfig != nil {
+			deployment.Spec.Template.Spec.DNSConfig = podDNSConfig
+			deployment.Spec.Template.Spec.DNSPolicy = "None"
 		}
-		deployment.Spec.Template.Spec.DNSConfig = podDNSConfig
-		deployment.Spec.Template.Spec.DNSPolicy = "None"
+
 		_, err = s.manager.client.AppsV1().Deployments(app.TenantID).Create(deployment)
 		if err != nil {
 			return fmt.Errorf("create deployment failure:%s;", err.Error())

--- a/worker/appm/controller/upgrade.go
+++ b/worker/appm/controller/upgrade.go
@@ -188,7 +188,8 @@ func (s *upgradeController) upgradeOne(app v1.AppService) error {
 	}
 	s.upgradeConfigMap(app)
 	if deployment := app.GetDeployment(); deployment != nil {
-		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, deployment.Namespace)
+
+		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, deployment.Namespace, s.manager.rbdNamespace, s.manager.rbdDNSName)
 		if err != nil {
 			return err
 		}
@@ -201,7 +202,7 @@ func (s *upgradeController) upgradeOne(app v1.AppService) error {
 		}
 	}
 	if statefulset := app.GetStatefulSet(); statefulset != nil {
-		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, statefulset.Namespace)
+		podDNSConfig, err := workerutil.MakePodDNSConfig(s.manager.client, statefulset.Namespace, s.manager.rbdNamespace, s.manager.rbdDNSName)
 		if err != nil {
 			return err
 		}

--- a/worker/util/dns.go
+++ b/worker/util/dns.go
@@ -11,10 +11,6 @@ import (
 )
 
 func dns2Config(endpoint *corev1.Endpoints, podNamespace string) (podDNSConfig *corev1.PodDNSConfig) {
-	if endpoint == nil {
-		logrus.Debug("rbd-dns endpoint is nil")
-		return nil
-	}
 	servers := make([]string, 0)
 	for _, sub := range endpoint.Subsets {
 		for _, addr := range sub.Addresses {
@@ -32,6 +28,10 @@ func dns2Config(endpoint *corev1.Endpoints, podNamespace string) (podDNSConfig *
 
 // MakePodDNSConfig make pod dns config
 func MakePodDNSConfig(clientset kubernetes.Interface, podNamespace, rbdNamespace, rbdEndpointDNSName string) (podDNSConfig *corev1.PodDNSConfig) {
-	endpoints, _ := clientset.CoreV1().Endpoints(rbdNamespace).Get(rbdEndpointDNSName, metav1.GetOptions{})
+	endpoints, err := clientset.CoreV1().Endpoints(rbdNamespace).Get(rbdEndpointDNSName, metav1.GetOptions{})
+	if err != nil {
+		logrus.Warningf("get rbd-dns[namespace: %s, name: %s] endpoints error: %s", rbdNamespace, rbdEndpointDNSName, err.Error())
+		return nil
+	}
 	return dns2Config(endpoints, podNamespace)
 }

--- a/worker/util/dns.go
+++ b/worker/util/dns.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	defaultRBDSystem = "rbd-system"
+	defaultRBDDNS    = "rbd-dns"
+)
+
+func dns2Config(endpoint *corev1.Endpoints, podNamespace string) (podDNSConfig *corev1.PodDNSConfig, err error) {
+	if endpoint == nil {
+		return nil, fmt.Errorf("rbd-dns endpoints is nil")
+	}
+	servers := make([]string, 0)
+	for _, sub := range endpoint.Subsets {
+		for _, addr := range sub.Addresses {
+			servers = append(servers, addr.IP)
+		}
+	}
+	searchRBDDNS := fmt.Sprintf("%s.svc.cluster.local", podNamespace)
+	ndotsValue := "5"
+	return &corev1.PodDNSConfig{
+		Nameservers: servers,
+		Options:     []corev1.PodDNSConfigOption{corev1.PodDNSConfigOption{Name: "ndots", Value: &ndotsValue}},
+		Searches:    []string{searchRBDDNS, "svc.cluster.local", "cluster.local"},
+	}, nil
+}
+
+// MakePodDNSConfig make pod dns config
+func MakePodDNSConfig(clientset *kubernetes.Clientset, podNamespace string) (podDNSConfig *corev1.PodDNSConfig, err error) {
+	namespace := os.Getenv("RBD_SYSTEM")
+	rbdName := os.Getenv("RBD_DNS")
+	if namespace == "" {
+		namespace = defaultRBDSystem
+	}
+	if rbdName == "" {
+		rbdName = defaultRBDDNS
+	}
+	endpoints, err := clientset.CoreV1().Endpoints(namespace).Get(rbdName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("found rbd-dns error: %s", err.Error())
+	}
+	podDNSConfig, err = dns2Config(endpoints, podNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("parse rbd-dns to dnsconfig error: %s", err.Error())
+	}
+	return podDNSConfig, nil
+}

--- a/worker/util/dns.go
+++ b/worker/util/dns.go
@@ -2,16 +2,11 @@ package util
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-)
-
-var (
-	defaultRBDSystem = "rbd-system"
-	defaultRBDDNS    = "rbd-dns"
 )
 
 func dns2Config(endpoint *corev1.Endpoints, podNamespace string) (podDNSConfig *corev1.PodDNSConfig, err error) {
@@ -34,16 +29,8 @@ func dns2Config(endpoint *corev1.Endpoints, podNamespace string) (podDNSConfig *
 }
 
 // MakePodDNSConfig make pod dns config
-func MakePodDNSConfig(clientset *kubernetes.Clientset, podNamespace string) (podDNSConfig *corev1.PodDNSConfig, err error) {
-	namespace := os.Getenv("RBD_SYSTEM")
-	rbdName := os.Getenv("RBD_DNS")
-	if namespace == "" {
-		namespace = defaultRBDSystem
-	}
-	if rbdName == "" {
-		rbdName = defaultRBDDNS
-	}
-	endpoints, err := clientset.CoreV1().Endpoints(namespace).Get(rbdName, metav1.GetOptions{})
+func MakePodDNSConfig(clientset *kubernetes.Clientset, podNamespace, rbdNamespace, rbdEndpointDNSName string) (podDNSConfig *corev1.PodDNSConfig, err error) {
+	endpoints, err := clientset.CoreV1().Endpoints(rbdNamespace).Get(rbdEndpointDNSName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("found rbd-dns error: %s", err.Error())
 	}


### PR DESCRIPTION
在启动和升级组件时，设置PodDNSConfig，使用rbd-dns的endpoint地址作为dns的nameserver