### PR TITLE
add extra hosts when builder source code

### DIFF
--- a/builder/build/build.go
+++ b/builder/build/build.go
@@ -87,6 +87,7 @@ type Request struct {
 	BuildEnvs     map[string]string
 	Logger        event.Logger
 	DockerClient  *client.Client
+	ExtraHosts    []string
 }
 
 //Commit Commit

--- a/builder/build/code_build.go
+++ b/builder/build/code_build.go
@@ -277,7 +277,8 @@ func (s *slugBuild) runBuildContainer(re *Request) error {
 		NetworkConfig: &sources.NetworkConfig{
 			NetworkMode: "host",
 		},
-		Args: []string{"local"},
+		Args:       []string{"local"},
+		ExtraHosts: re.ExtraHosts,
 	}
 	reader, err := s.getSourceCodeTarFile(re)
 	if err != nil {

--- a/builder/exector/exector.go
+++ b/builder/exector/exector.go
@@ -26,6 +26,10 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/docker/docker/client"
@@ -65,6 +69,19 @@ func NewManager(conf option.Config, mqc mqclient.MQClient) (Manager, error) {
 	if err != nil {
 		return nil, err
 	}
+	var restConfig *rest.Config // TODO fanyangyang use k8sutil.NewRestConfig
+	if conf.KubeConfig != "" {
+		restConfig, err = clientcmd.BuildConfigFromFlags("", conf.KubeConfig)
+	} else {
+		restConfig, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
 	etcdCli, err := clientv3.New(clientv3.Config{
 		Endpoints:   conf.EtcdEndPoints,
 		DialTimeout: 10 * time.Second,
@@ -82,6 +99,7 @@ func NewManager(conf option.Config, mqc mqclient.MQClient) (Manager, error) {
 	logrus.Infof("The maximum number of concurrent build tasks supported by the current node is %d", maxConcurrentTask)
 	return &exectorManager{
 		DockerClient:      dockerClient,
+		KubeClient:        kubeClient,
 		EtcdCli:           etcdCli,
 		mqClient:          mqc,
 		tasks:             make(chan *pb.TaskMessage, maxConcurrentTask),
@@ -94,6 +112,7 @@ func NewManager(conf option.Config, mqc mqclient.MQClient) (Manager, error) {
 
 type exectorManager struct {
 	DockerClient      *client.Client
+	KubeClient        kubernetes.Interface
 	EtcdCli           *clientv3.Client
 	tasks             chan *pb.TaskMessage
 	callback          func(*pb.TaskMessage)
@@ -288,6 +307,9 @@ func (e *exectorManager) buildFromImage(task *pb.TaskMessage) {
 func (e *exectorManager) buildFromSourceCode(task *pb.TaskMessage) {
 	i := NewSouceCodeBuildItem(task.TaskBody)
 	i.DockerClient = e.DockerClient
+	i.KubeClient = e.KubeClient
+	i.RbdNamespace = e.cfg.RbdNamespace
+	i.RbdRepoName = e.cfg.RbdRepoName
 	i.Logger.Info("Build app version from source code start", map[string]string{"step": "builder-exector", "status": "starting"})
 	start := time.Now()
 	defer event.GetManager().ReleaseLogger(i.Logger)

--- a/builder/sources/container.go
+++ b/builder/sources/container.go
@@ -89,6 +89,7 @@ func (ds *DockerService) CreateContainer(config *ContainerConfig) (string, error
 	hc := &dockercontainer.HostConfig{
 		Binds:       generateMountBindings(config.GetMounts()),
 		NetworkMode: dockercontainer.NetworkMode(config.NetworkConfig.NetworkMode),
+		ExtraHosts:  config.ExtraHosts,
 	}
 	// Set devices for container.
 	devices := make([]dockercontainer.DeviceMapping, len(config.Devices))

--- a/builder/sources/container_config.go
+++ b/builder/sources/container_config.go
@@ -137,6 +137,7 @@ type ContainerConfig struct {
 	AttachStdout  bool
 	AttachStderr  bool
 	NetworkConfig *NetworkConfig
+	ExtraHosts    []string
 }
 
 //GetMetadata GetMetadata

--- a/cmd/builder/option/option.go
+++ b/cmd/builder/option/option.go
@@ -45,6 +45,8 @@ type Config struct {
 	CleanUp              bool
 	Topic                string
 	LogPath              string
+	RbdNamespace         string
+	RbdRepoName          string
 }
 
 //Builder  builder server
@@ -79,6 +81,9 @@ func (a *Builder) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&a.CleanUp, "clean-up", true, "Turn on build version cleanup")
 	fs.StringVar(&a.Topic, "topic", "builder", "Topic in mq,you coule choose `builder` or `windows_builder`")
 	fs.StringVar(&a.LogPath, "log-path", "/grdata/logs", "Where Docker log files and event log files are stored.")
+	fs.StringVar(&a.RbdNamespace, "rbd-namespace", "rbd-system", "rbd component namespace")
+	fs.StringVar(&a.RbdRepoName, "rbd-repo", "rbd-repo", "rbd component repo's name")
+
 }
 
 //SetLog 设置log

--- a/util/language.go
+++ b/util/language.go
@@ -45,6 +45,7 @@ var translationMetadata = map[string]string{
 	"Check for log location code errors":             "建议查看日志定位代码错误",
 	"Check for log location imgae source errors":     "建议查看日志定位镜像源错误",
 	"create share image task error":                  "分享任务失败，请检查服务信息或查看日志",
+	"get rbd-repo ip failure":                        "获取依赖仓库IP地址失败，请检查rbd-repo组件信息",
 }
 
 //Translation Translation English to Chinese


### PR DESCRIPTION
修改chaos组件，添加启动参数，配置rbd组件使用的命名空间和repo组件的默认名字，由此获取repo对应的endpoint中的IP，来解析maven.goodrain.me和lang.goodrain.me到repo组件中

方式：通过在构建组件时添加extraHosts的方式将maven.goodrain.me和lang.goodrain.me指向repo对应的IP上