### PR TITLE
use k8snodeid as node id

### DIFF
--- a/cmd/node/option/conf.go
+++ b/cmd/node/option/conf.go
@@ -67,7 +67,7 @@ type Conf struct {
 	K8SConfPath                     string //absolute path to the kubeconfig file
 	LogLevel                        string
 	LogFile                         string
-	HostIDFile                      string
+	HostID                          string
 	HostIP                          string
 	RunMode                         string //ACP_NODE 运行模式:master,node
 	NodeRule                        string //节点属性 compute manage storage
@@ -138,7 +138,7 @@ func (a *Conf) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.LogFile, "log-file", "", "the log file path that log output")
 	fs.StringVar(&a.PrometheusAPI, "prometheus", "http://localhost:9999", "the prometheus server address")
 	fs.StringVar(&a.NodePath, "nodePath", "/rainbond/nodes", "the path of node in etcd")
-	fs.StringVar(&a.HostIDFile, "nodeid-file", "/opt/rainbond/etc/node/node_host_uuid.conf", "the unique ID for this node. Just specify, don't modify")
+	fs.StringVar(&a.HostID, "nodeid", "", "the unique ID for this node. Just specify, don't modify")
 	fs.StringVar(&a.HostIP, "hostIP", "", "the host ip you can define. default get ip from eth0")
 	fs.StringSliceVar(&a.EventLogServer, "event-log-server", []string{"127.0.0.1:6366"}, "host:port slice of event log server")
 	fs.StringVar(&a.ConfigStoragePath, "config-path", "/rainbond/acp_configs", "the path of config to store(new)")
@@ -238,6 +238,9 @@ func (a *Conf) parse() error {
 	//init api listen port, can not custom
 	if a.APIAddr == "" {
 		a.APIAddr = ":6100"
+	}
+	if a.HostID == "" {
+		return fmt.Errorf("kubernetes node id can't empty")
 	}
 	return nil
 }

--- a/node/masterserver/node/cluster_test.go
+++ b/node/masterserver/node/cluster_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2014-2018 Goodrain Co., Ltd.
+// RAINBOND, Application Management Platform
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version. For any non-GPL usage of Rainbond,
+// one or multiple Commercial Licenses authorized by Goodrain Co., Ltd.
+// must be obtained first.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package node
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestCluster_handleNodeStatus(t *testing.T) {
+	config, err := clientcmd.BuildConfigFromFlags("", "/Users/fanyangyang/Documents/company/goodrain/remote/192.168.2.200/admin.kubeconfig")
+	if err != nil {
+		return
+	}
+	cli, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	node, err := cli.CoreV1().Nodes().Get("192.168.2.200", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("node is :%+v", node)
+	t.Logf("cpu:%v", node.Status.Allocatable.Cpu().Value())
+	t.Logf("mem: %v", node.Status.Allocatable.Memory().Value())
+}

--- a/node/nodem/node_manager.go
+++ b/node/nodem/node_manager.go
@@ -69,7 +69,6 @@ func NewNodeManager(conf *option.Conf) (*NodeManager, error) {
 	}
 	clm := logger.CreatContainerLogManage(conf)
 	controller := controller.NewManagerService(conf, healthyManager, cluster)
-	uid, err := util.ReadHostID(conf.HostIDFile)
 	if err != nil {
 		return nil, fmt.Errorf("Get host id error:%s", err.Error())
 	}
@@ -95,7 +94,7 @@ func NewNodeManager(conf *option.Conf) (*NodeManager, error) {
 		healthy:        healthyManager,
 		controller:     controller,
 		clm:            clm,
-		currentNode:    &client.HostNode{ID: uid},
+		currentNode:    &client.HostNode{ID: conf.HostID},
 		imageGCManager: imageGCManager,
 	}
 	return nodem, nil


### PR DESCRIPTION
node启动时，使用k8s node的name作为node的id，从而正确的获取node所在节点的资源信息