### PR TITLE
adapted to kubelet 1.16

### DIFF
--- a/api/handler/service.go
+++ b/api/handler/service.go
@@ -1762,7 +1762,7 @@ func (s *ServiceAction) GetPodContainerMemory(podNames []string) (map[string]map
 	memoryUsageMap := make(map[string]map[string]string, 10)
 	proxy := GetPrometheusProxy()
 	queryName := strings.Join(podNames, "|")
-	query := fmt.Sprintf(`container_memory_usage_bytes{pod_name=~"%s"}`, queryName)
+	query := fmt.Sprintf(`container_memory_usage_bytes{pod=~"%s"}`, queryName)
 	proQuery := strings.Replace(query, " ", "%20", -1)
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://127.0.0.1:9999/api/v1/query?query=%s", proQuery), nil)
 	if err != nil {
@@ -1787,10 +1787,10 @@ func (s *ServiceAction) GetPodContainerMemory(podNames []string) (map[string]map
 				var containerName, podName string
 				var valuesBytes string
 				if cname, ok := re["metric"].(map[string]interface{}); ok {
-					if containerName, ok = cname["container_name"].(string); !ok {
+					if containerName, ok = cname["container"].(string); !ok {
 						continue
 					}
-					if podName, ok = cname["pod_name"].(string); !ok {
+					if podName, ok = cname["pod"].(string); !ok {
 						continue
 					}
 				} else {

--- a/cmd/monitor/option/option.go
+++ b/cmd/monitor/option/option.go
@@ -55,9 +55,6 @@ type Config struct {
 	QueryTimeout         string
 	QueryMaxConcurrency  string
 	CadvisorListenPort   int
-	CadvisorCaFile       string
-	CadvisorCertFile     string
-	CadvisorKeyFile      string
 	MysqldExporter       string
 	KSMExporter          string
 }
@@ -131,9 +128,6 @@ func NewConfig() *Config {
 			Retention:        "7d",
 		},
 		CadvisorListenPort: 10250,
-		CadvisorCaFile:     "/opt/rainbond/etc/kubernetes/ssl/ca.pem",
-		CadvisorCertFile:   "/opt/rainbond/etc/kubernetes/ssl/admin.pem",
-		CadvisorKeyFile:    "/opt/rainbond/etc/kubernetes/ssl/admin-key.pem",
 	}
 
 	return config
@@ -144,9 +138,6 @@ func (c *Config) AddFlag(cmd *pflag.FlagSet) {
 	cmd.StringVar(&c.EtcdEndpointsLine, "etcd-endpoints", c.EtcdEndpointsLine, "etcd endpoints list.")
 	cmd.StringVar(&c.AdvertiseAddr, "advertise-addr", c.AdvertiseAddr, "advertise address, and registry into etcd.")
 	cmd.IntVar(&c.CadvisorListenPort, "cadvisor-listen-port", c.CadvisorListenPort, "kubelet cadvisor listen port in all node")
-	cmd.StringVar(&c.CadvisorCaFile, "cadvisor-ca", c.CadvisorCaFile, "kubelet ca file")
-	cmd.StringVar(&c.CadvisorCertFile, "cadvisor-cert", c.CadvisorCertFile, "kubelet cert file")
-	cmd.StringVar(&c.CadvisorKeyFile, "cadvisor-key", c.CadvisorKeyFile, "kubelet cert key file")
 	cmd.StringSliceVar(&c.AlertManagerURL, "alertmanager-address", c.AlertManagerURL, "AlertManager url.")
 	cmd.StringVar(&c.MysqldExporter, "mysqld-exporter", c.MysqldExporter, "mysqld exporter address. eg: 127.0.0.1:9104")
 	cmd.StringVar(&c.KSMExporter, "kube-state-metrics", c.KSMExporter, "kube-state-metrics, current server's kube-state-metrics address")

--- a/monitor/callback/cadvisor.go
+++ b/monitor/callback/cadvisor.go
@@ -39,9 +39,6 @@ type Cadvisor struct {
 	Prometheus      *prometheus.Manager
 	sortedEndpoints []string
 	ListenPort      int
-	CaFile          string
-	CertFile        string
-	KeyFile         string
 
 	endpoints []*config.Endpoint
 }
@@ -80,7 +77,7 @@ func (c *Cadvisor) toScrape() *prometheus.ScrapeConfig {
 		JobName:        c.Name(),
 		ScrapeInterval: model.Duration(15 * time.Second),
 		ScrapeTimeout:  model.Duration(10 * time.Second),
-		MetricsPath:    "metrics/cadvisor",
+		MetricsPath:    "/metrics/cadvisor",
 		ServiceDiscoveryConfig: prometheus.ServiceDiscoveryConfig{
 			StaticConfigs: []*prometheus.Group{
 				{
@@ -94,10 +91,10 @@ func (c *Cadvisor) toScrape() *prometheus.ScrapeConfig {
 		Scheme: "https",
 		HTTPClientConfig: prometheus.HTTPClientConfig{
 			TLSConfig: prometheus.TLSConfig{
-				CAFile:   c.CaFile,
-				CertFile: c.CertFile,
-				KeyFile:  c.KeyFile,
+				CAFile: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+				InsecureSkipVerify: true,
 			},
+			BearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 		},
 	}
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -67,9 +67,6 @@ func (d *Monitor) Start() {
 	go d.discoverCadvisor(&callback.Cadvisor{
 		Prometheus: d.manager,
 		ListenPort: d.config.CadvisorListenPort,
-		CaFile:     d.config.CadvisorCaFile,
-		CertFile:   d.config.CadvisorCertFile,
-		KeyFile:    d.config.CadvisorKeyFile,
 	}, d.ctx.Done())
 }
 


### PR DESCRIPTION
adapted to k8s 1.1.6:
1.  use label pod instead of pod_name; use container instead of container_name. ref [removed-metrics](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#removed-metrics)
2. cAdvisor json endpoints have been deprecated since 1.15(kubernetes/kubernetes#78504)