### PR TITLE
Fix wrong usage of context

### DIFF
--- a/api/handler/service_check.go
+++ b/api/handler/service_check.go
@@ -24,14 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pquerna/ffjson/ffjson"
-
 	"github.com/Sirupsen/logrus"
 	api_model "github.com/goodrain/rainbond/api/model"
 	"github.com/goodrain/rainbond/api/util"
 	"github.com/goodrain/rainbond/builder/exector"
 	client "github.com/goodrain/rainbond/mq/client"
 	tutil "github.com/goodrain/rainbond/util"
+	"github.com/pquerna/ffjson/ffjson"
 	"github.com/twinj/uuid"
 )
 
@@ -82,8 +81,8 @@ func (s *ServiceAction) GetServiceCheckInfo(uuid string) (*exector.ServiceCheckR
 	k := fmt.Sprintf("/servicecheck/%s", uuid)
 	var si exector.ServiceCheckResult
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	resp, err := s.EtcdCli.Get(ctx, k)
-	cancel()
 	if err != nil {
 		logrus.Errorf("get etcd k %s error, %v", k, err)
 		return nil, util.CreateAPIHandleError(500, err)

--- a/builder/exector/exector.go
+++ b/builder/exector/exector.go
@@ -95,7 +95,6 @@ func NewManager(conf option.Config, mqc mqclient.MQClient) (Manager, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	etcdCli, err := etcdutil.NewClient(ctx, etcdClientArgs)
 	if err != nil {
-		cancel()
 		return nil, err
 	}
 	var maxConcurrentTask int

--- a/cmd/node/option/conf.go
+++ b/cmd/node/option/conf.go
@@ -204,22 +204,12 @@ func (a *Conf) SetLog() {
 }
 
 //ParseClient handle config and create some api
-func (a *Conf) ParseClient() (err error) {
+func (a *Conf) ParseClient(ctx context.Context, etcdClientArgs *etcdutil.ClientArgs) (err error) {
 	a.DockerCli, err = dockercli.NewEnvClient()
 	if err != nil {
 		return err
 	}
 	logrus.Infof("begin create etcd client: %s", a.EtcdEndpoints)
-	etcdClientArgs := &etcdutil.ClientArgs{
-		Endpoints:        a.EtcdEndpoints,
-		CaFile:           a.EtcdCaFile,
-		CertFile:         a.EtcdCertFile,
-		KeyFile:          a.EtcdKeyFile,
-		AutoSyncInterval: time.Second * 30,
-		DialTimeout:      a.EtcdDialTimeout,
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	for {
 		a.EtcdCli, err = etcdutil.NewClient(ctx, etcdClientArgs)
 		if err != nil {

--- a/db/etcd/etcd.go
+++ b/db/etcd/etcd.go
@@ -47,9 +47,7 @@ func CreateManager(config config.Config) (*Manager, error) {
 		CertFile:  config.EtcdCertFile,
 		KeyFile:   config.EtcdKeyFile,
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cli, err := etcdutil.NewClient(ctx, etcdClientArgs)
+	cli, err := etcdutil.NewClient(context.Background(), etcdClientArgs)
 	if err != nil {
 		etcdutil.HandleEtcdError(err)
 		return nil, err

--- a/discover.v2/register.go
+++ b/discover.v2/register.go
@@ -37,7 +37,6 @@ import (
 type KeepAlive struct {
 	cancel         context.CancelFunc
 	EtcdClientArgs *etcdutil.ClientArgs
-	etcdcli        *clientv3.Client
 	ServerName     string
 	HostName       string
 	Endpoint       string
@@ -75,7 +74,7 @@ func CreateKeepAlive(etcdClientArgs *etcdutil.ClientArgs, ServerName string, Pro
 		Endpoint:       fmt.Sprintf("%s:%d", HostIP, Port),
 		TTL:            5,
 		Done:           make(chan struct{}),
-		etcdcli:        etcdclient,
+		etcdClient:     etcdclient,
 		cancel:         cancel,
 	}
 	if Protocol == "" {

--- a/eventlog/cluster/discover/manager.go
+++ b/eventlog/cluster/discover/manager.go
@@ -187,9 +187,7 @@ func (d *EtcdDiscoverManager) Run() error {
 		CertFile:  d.conf.EtcdCertFile,
 		KeyFile:   d.conf.EtcdKeyFile,
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	d.etcdclientv3, err = etcdutil.NewClient(ctx, etcdClientArgs)
+	d.etcdclientv3, err = etcdutil.NewClient(d.context, etcdClientArgs)
 	if err != nil {
 		d.log.Error("Create etcd v3 client error.", err.Error())
 		return err

--- a/gateway/cluster/node.go
+++ b/gateway/cluster/node.go
@@ -46,6 +46,7 @@ func CreateNodeManager(config option.Config) (*NodeManager, error) {
 	if err := ipManager.Start(); err != nil {
 		return nil, err
 	}
+	defer ipManager.Stop()
 	nm.ipManager = ipManager
 	if ok := nm.checkGatewayPort(); !ok {
 		return nil, fmt.Errorf("Check gateway node port failure")

--- a/gateway/controller/controller.go
+++ b/gateway/controller/controller.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/goodrain/rainbond/gateway/cluster"
 
-	"k8s.io/client-go/kubernetes"
 	"github.com/Sirupsen/logrus"
 	client "github.com/coreos/etcd/clientv3"
 	"github.com/eapache/channels"
@@ -40,6 +39,7 @@ import (
 	v1 "github.com/goodrain/rainbond/gateway/v1"
 	etcdutil "github.com/goodrain/rainbond/util/etcd"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/ingress-nginx/task"
 )
@@ -238,8 +238,6 @@ func NewGWController(ctx context.Context, clientset kubernetes.Interface, cfg *o
 			KeyFile:     cfg.EtcdKeyFile,
 			DialTimeout: time.Duration(cfg.EtcdTimeout) * time.Second,
 		}
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 		cli, err := etcdutil.NewClient(ctx, etcdClientArgs)
 		if err != nil {
 			return nil, err

--- a/mq/api/mq/mq.go
+++ b/mq/api/mq/mq.go
@@ -78,9 +78,7 @@ func (e *etcdQueue) Start() error {
 		KeyFile:     e.config.EtcdKeyFile,
 		DialTimeout: time.Duration(e.config.EtcdTimeout) * time.Second,
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cli, err := etcdutil.NewClient(ctx, etcdClientArgs)
+	cli, err := etcdutil.NewClient(context.Background(), etcdClientArgs)
 	if err != nil {
 		etcdutil.HandleEtcdError(err)
 		return err

--- a/node/core/store/client.go
+++ b/node/core/store/client.go
@@ -46,16 +46,7 @@ type Client struct {
 }
 
 //NewClient 创建client
-func NewClient(cfg *conf.Conf) (err error) {
-	etcdClientArgs := &etcdutil.ClientArgs{
-		Endpoints:   cfg.EtcdEndpoints,
-		CaFile:      cfg.EtcdCaFile,
-		CertFile:    cfg.EtcdCertFile,
-		KeyFile:     cfg.EtcdKeyFile,
-		DialTimeout: cfg.EtcdDialTimeout,
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func NewClient(ctx context.Context, cfg *conf.Conf, etcdClientArgs *etcdutil.ClientArgs) (err error) {
 	cli, err := etcdutil.NewClient(ctx, etcdClientArgs)
 	if err != nil {
 		return

--- a/worker/client/client.go
+++ b/worker/client/client.go
@@ -59,12 +59,10 @@ func NewClient(ctx context.Context, conf AppRuntimeSyncClientConf) (*AppRuntimeS
 		CertFile:  conf.EtcdCertFile,
 		KeyFile:   conf.EtcdKeyFile,
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	c, err := etcdutil.NewClient(ctx, etcdClientArgs)
 	r := &etcdnaming.GRPCResolver{Client: c}
 	b := grpc.RoundRobin(r)
-	arsc.cc, err = grpc.DialContext(ctx, "/rainbond/discover/app_sync_runtime_server", grpc.WithBalancer(b), grpc.WithInsecure())
+	arsc.cc, err = grpc.DialContext(ctx, "/rainbond/discover/app_sync_runtime_server", grpc.WithBalancer(b), grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
建立 grpc 时 ，加上 grpc.WithBlock() 参数，确保 grpc 的 address 不为 nli