### PR TITLE
make kube-conf detault to ""

### DIFF
--- a/cmd/gateway/option/option.go
+++ b/cmd/gateway/option/option.go
@@ -99,7 +99,7 @@ type ListenPorts struct {
 // AddFlags adds flags
 func (g *GWServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&g.LogLevel, "log-level", "debug", "the gateway log level")
-	fs.StringVar(&g.K8SConfPath, "kube-conf", "/opt/rainbond/etc/kubernetes/kubecfg/admin.kubeconfig", "absolute path to the kubeconfig file")
+	fs.StringVar(&g.K8SConfPath, "kube-conf", "", "absolute path to the kubeconfig file")
 	fs.IntVar(&g.ListenPorts.Status, "status-port", 18080, `Port to use for the lua HTTP endpoint configuration.`)
 	fs.IntVar(&g.ListenPorts.Stream, "stream-port", 18081, `Port to use for the lua TCP/UDP endpoint configuration.`)
 	fs.IntVar(&g.ListenPorts.Health, "healthz-port", 10254, `Port to use for the healthz endpoint.`)


### PR DESCRIPTION
不指定kube apiserver的证书文件，默认使用 servicec account