### PR TITLE
fix '/v2/cluster' 500

### DIFF
--- a/node/kubecache/kube_cache.go
+++ b/node/kubecache/kube_cache.go
@@ -110,6 +110,7 @@ func NewKubeClient(cfg *conf.Conf, clientset kubernetes.Interface) (KubeClient, 
 	sharedInformers.Core().V1().Pods().Informer()
 	sharedInformers.Start(stop)
 	return &kubeClient{
+		kubeclient:      clientset,
 		stop:            stop,
 		sharedInformers: sharedInformers,
 	}, nil


### PR DESCRIPTION
kubeclient 为空, 导致了 /v2/cluster 接口去获取 node 列表是发生了空指针, 所以会返回 500.