### PR TITLE
fix 'runtime.Object is nil'

### DIFF
--- a/discover.v2/k8s_discover.go
+++ b/discover.v2/k8s_discover.go
@@ -84,6 +84,9 @@ func (k *k8sDiscover) discover(name string, callback CallbackUpdate) {
 		case <-ctx.Done():
 			return
 		case event := <-w.ResultChan():
+			if event.Object == nil {
+				continue
+			}
 			pod := event.Object.(*corev1.Pod)
 			ep := endpointForPod(pod)
 			switch event.Type {


### PR DESCRIPTION
修复问题: panic: interface conversion: runtime.Object is nil, not *v1.Pod.
event.Object 可能为nil, 在这种情况下, 应该忽略, 不处理