### PR TITLE
fix local storage

### DIFF
--- a/node/nodem/node_manager.go
+++ b/node/nodem/node_manager.go
@@ -324,7 +324,7 @@ func (n *NodeManager) getInitLabel(node *client.HostNode) map[string]string {
 		node.HostName = hostname
 	}
 	labels["rainbond_node_hostname"] = node.HostName
-	labels["rainbond_node_ip"] = node.InternalIP
+	labels["kubernetes.io/hostname"] = node.InternalIP
 	return labels
 }
 

--- a/worker/master/volumes/provider/lib/controller/controller.go
+++ b/worker/master/volumes/provider/lib/controller/controller.go
@@ -515,7 +515,7 @@ func NewProvisionController(
 			case "rainbondslsc":
 				nodeIP := func() string {
 					for _, me := range pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions {
-						if me.Key != "rainbond_node_ip" {
+						if me.Key != "kubernetes.io/hostname" {
 							continue
 						}
 						return me.Values[0]

--- a/worker/master/volumes/provider/rainbondsslc.go
+++ b/worker/master/volumes/provider/rainbondsslc.go
@@ -192,8 +192,8 @@ func (p *rainbondsslcProvisioner) Provision(options controller.VolumeOptions) (*
 		if options.SelectedNode == nil {
 			return nil, fmt.Errorf("do not select an appropriate node for local volume")
 		}
-		if _, ok := options.SelectedNode.Labels["rainbond_node_ip"]; !ok {
-			return nil, fmt.Errorf("select node(%s) do not have label rainbond_node_ip ", options.SelectedNode.Name)
+		if _, ok := options.SelectedNode.Labels["kubernetes.io/hostname"]; !ok {
+			return nil, fmt.Errorf("select node(%s) do not have label kubernetes.io/hostname ", options.SelectedNode.Name)
 		}
 	}
 	path, err := p.createPath(options)
@@ -228,9 +228,9 @@ func (p *rainbondsslcProvisioner) Provision(options controller.VolumeOptions) (*
 						v1.NodeSelectorTerm{
 							MatchExpressions: []v1.NodeSelectorRequirement{
 								v1.NodeSelectorRequirement{
-									Key:      "rainbond_node_ip",
+									Key:      "kubernetes.io/hostname",
 									Operator: v1.NodeSelectorOpIn,
-									Values:   []string{options.SelectedNode.Labels["rainbond_node_ip"]},
+									Values:   []string{options.SelectedNode.Labels["kubernetes.io/hostname"]},
 								},
 							},
 						},


### PR DESCRIPTION
修复本地存储不可用

问题：本地存储provisoner在获取节点IP时标签错误，获取不到节点IP
修复方案：修改provisoner获取节点IP时使用的标签