### PR TITLE
change nginx log level

### DIFF
--- a/hack/contrib/docker/gateway/nginx/lua/tcp_udp_balancer.lua
+++ b/hack/contrib/docker/gateway/nginx/lua/tcp_udp_balancer.lua
@@ -151,7 +151,7 @@ function _M.balance()
   end
 
   ngx_balancer.set_more_tries(1)
-  ngx.log(ngx.ERR, string.format("select peer %s", peer))
+  ngx.log(ngx.DEBUG, string.format("select peer %s", peer))
   local ok, err = ngx_balancer.set_current_peer(peer)
   if not ok then
     ngx.log(ngx.ERR, string.format("error while setting current upstream peer %s: %s", peer, err))


### PR DESCRIPTION
更改 `select peer %s", peer` 这行日志的级别为 Info, 避免一直打印这个日志.