### PR TITLE
fix update plugin discover config

### DIFF
--- a/db/mysql/dao/plugin.go
+++ b/db/mysql/dao/plugin.go
@@ -412,7 +412,8 @@ func (t *PluginVersionConfigDaoImpl) AddModel(mo model.Interface) error {
 		}
 	} else {
 		config.ID = oldconfig.ID
-		t.UpdateModel(config)
+		config.CreatedAt = oldconfig.CreatedAt
+		return t.UpdateModel(config)
 	}
 	return nil
 }


### PR DESCRIPTION
更新插件的配置时发生错误 `Incorrect datetime value: '0000-00-00' for column 'create_time' at row 1"`, 且错误被忽略了