### PR TITLE
fix history log not found

### DIFF
--- a/api/controller/websocket.go
+++ b/api/controller/websocket.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"path"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/go-chi/chi"
@@ -29,6 +30,7 @@ import (
 	"github.com/goodrain/rainbond/api/handler"
 	"github.com/goodrain/rainbond/api/middleware"
 	"github.com/goodrain/rainbond/api/proxy"
+	"github.com/goodrain/rainbond/util/constants"
 )
 
 //DockerConsole docker console
@@ -138,7 +140,7 @@ var logFile *LogFile
 func GetLogFile() *LogFile {
 	root := os.Getenv("SERVICE_LOG_ROOT")
 	if root == "" {
-		root = "/grdata/downloads/log/"
+		root = constants.GrdataLogPath
 	}
 	logrus.Infof("service logs file root path is :%s", root)
 	if logFile == nil {
@@ -153,7 +155,7 @@ func GetLogFile() *LogFile {
 func (d LogFile) Get(w http.ResponseWriter, r *http.Request) {
 	gid := chi.URLParam(r, "gid")
 	filename := chi.URLParam(r, "filename")
-	filePath := d.Root + gid + "/" + filename
+	filePath := path.Join(d.Root, gid, filename)
 	if isExist(filePath) {
 		http.ServeFile(w, r, filePath)
 	} else {

--- a/api/handler/eventlog_interface.go
+++ b/api/handler/eventlog_interface.go
@@ -19,13 +19,14 @@
 package handler
 
 import (
+	"github.com/goodrain/rainbond/api/model"
 	api_model "github.com/goodrain/rainbond/api/model"
 	dbmodel "github.com/goodrain/rainbond/db/model"
 )
 
 //EventHandler event handler interface
 type EventHandler interface {
-	GetLogList(serviceAlias string) ([]string, error)
+	GetLogList(serviceAlias string) ([]*model.HistoryLogFile, error)
 	GetLogInstance(serviceID string) (string, error)
 	GetLevelLog(eventID string, level string) (*api_model.DataLog, error)
 	GetLogFile(serviceAlias, fileName string) (string, string, error)

--- a/api/model/event_log.go
+++ b/api/model/event_log.go
@@ -1,0 +1,7 @@
+package model
+
+// HistoryLogFile represents a history log file for service
+type HistoryLogFile struct {
+	Filename     string `json:"filename"`
+	RelativePath string `json:"relative_path"`
+}

--- a/cmd/gateway/option/option.go
+++ b/cmd/gateway/option/option.go
@@ -54,6 +54,7 @@ type Config struct {
 	WorkerProcesses    int
 	WorkerRlimitNofile int
 	ErrorLog           string
+	ErrorLogLevel      string
 	WorkerConnections  int
 	//essential for linux, optmized to serve many clients with each thread
 	EnableEpool       bool
@@ -68,11 +69,11 @@ type Config struct {
 
 	EnableMetrics bool
 
-	NodeName           string
-	HostIP             string
-	IgnoreInterface    []string
-	ShareMemory        uint64
-	SyncRateLimit      float32
+	NodeName        string
+	HostIP          string
+	IgnoreInterface []string
+	ShareMemory     uint64
+	SyncRateLimit   float32
 }
 
 // ListenPorts describe the ports required to run the gateway controller
@@ -98,7 +99,8 @@ func (g *GWServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&g.WorkerRlimitNofile, "worker-rlimit-nofile", 200000, "Number of file descriptors used for Nginx. This is set in the OS with 'ulimit -n 200000'")
 	fs.BoolVar(&g.EnableEpool, "enable-epool", true, "essential for linux, optmized to serve many clients with each thread")
 	fs.BoolVar(&g.EnableMultiAccept, "enable-multi-accept", true, "Accept as many connections as possible, after nginx gets notification about a new connection.")
-	fs.StringVar(&g.ErrorLog, "error-log", "/dev/stderr crit", "only log critical errors")
+	fs.StringVar(&g.ErrorLog, "error-log", "/dev/stderr", "nginx log file, stderr or syslog")
+	fs.StringVar(&g.ErrorLogLevel, "errlog-level", "crit", "log level")
 	fs.StringVar(&g.NginxUser, "nginx-user", "root", "nginx user name")
 	fs.IntVar(&g.KeepaliveRequests, "keepalive-requests", 10000, "Number of requests a client can make over the keep-alive connection. ")
 	fs.IntVar(&g.KeepaliveTimeout, "keepalive-timeout", 30, "Timeout for keep-alive connections. Server will close connections after this time.")

--- a/gateway/controller/openresty/model/nginx.go
+++ b/gateway/controller/openresty/model/nginx.go
@@ -12,6 +12,7 @@ type Nginx struct {
 	WorkerProcesses    int
 	WorkerRlimitNofile int
 	ErrorLog           string
+	ErrorLogLevel      string
 	User               string
 	EventLog           EventLog
 	Events             Events
@@ -50,6 +51,7 @@ func NewNginx(conf option.Config) *Nginx {
 		WorkerRlimitNofile: conf.WorkerRlimitNofile,
 		User:               conf.NginxUser,
 		ErrorLog:           conf.ErrorLog,
+		ErrorLogLevel:      conf.ErrorLogLevel,
 		Events: Events{
 			WorkerConnections: conf.WorkerConnections,
 			EnableEpoll:       conf.EnableEpool,

--- a/grctl/cmd/service.go
+++ b/grctl/cmd/service.go
@@ -31,6 +31,7 @@ import (
 	eventdb "github.com/goodrain/rainbond/eventlog/db"
 	"github.com/goodrain/rainbond/grctl/clients"
 	coreutil "github.com/goodrain/rainbond/util"
+	"github.com/goodrain/rainbond/util/constants"
 	"github.com/gorilla/websocket"
 	"github.com/gosuri/uitable"
 	"github.com/tidwall/gjson"
@@ -216,7 +217,7 @@ func getEventLog(c *cli.Context) error {
 		}
 	} else {
 		logdb := &eventdb.EventFilePlugin{
-			HomePath: "/grdata/downloads/log/",
+			HomePath: constants.GrdataLogPath,
 		}
 		list, err := logdb.GetMessages(eventID, "debug", 0)
 		if err != nil {

--- a/hack/contrib/docker/gateway/nginx/lua/tcp_udp_balancer.lua
+++ b/hack/contrib/docker/gateway/nginx/lua/tcp_udp_balancer.lua
@@ -61,7 +61,6 @@ local function sync_backend(backend)
     return
   end
 
-  ngx.log(ngx.INFO, string.format("backend ", backend.name))
   local implementation = get_implementation(backend)
   local balancer = balancers[backend.name]
 
@@ -138,6 +137,7 @@ end
 
 function _M.balance()
   local balancer = get_balancer()
+  ngx.log(ngx.DEBUG, string.format("found balancer %s for %s", balancer.name, ngx.var.proxy_upstream_name))
   if not balancer then
     local backend_name = ngx.var.proxy_upstream_name
     ngx.log(ngx.ERR, string.format("not balancer %s", backend_name))
@@ -151,7 +151,7 @@ function _M.balance()
   end
 
   ngx_balancer.set_more_tries(1)
-  ngx.log(ngx.DEBUG, string.format("select peer %s", peer))
+  ngx.log(ngx.DEBUG, string.format("select peer %s for %s", peer, ngx.var.proxy_upstream_name))
   local ok, err = ngx_balancer.set_current_peer(peer)
   if not ok then
     ngx.log(ngx.ERR, string.format("error while setting current upstream peer %s: %s", peer, err))

--- a/hack/contrib/docker/gateway/nginxtmp/nginx.tmpl
+++ b/hack/contrib/docker/gateway/nginxtmp/nginx.tmpl
@@ -1,6 +1,6 @@
 {{ if .User }} user {{.User}};{{ end }}
 worker_processes  {{.WorkerProcesses}};
-error_log  {{.ErrorLog}};
+error_log  {{.ErrorLog}} {{.ErrorLogLevel}};
 worker_rlimit_nofile {{.WorkerRlimitNofile}};
 daemon off;
 

--- a/util/constants/constants.go
+++ b/util/constants/constants.go
@@ -3,4 +3,6 @@ package constants
 const (
 	// DefImageRepository default private image repository
 	DefImageRepository = "goodrain.me"
+	// GrdataLogPath -
+	GrdataLogPath = "/grdata/logs"
 )


### PR DESCRIPTION
获取不到日志的原因是 `api 获取日志时用的路径是 /grdata/downloads/log/, 而日志实质存放的路径是 /grdata/logs`. 
解决方法: 统一使用 `/grdata/logs`, 并用常量 constants.GrdataLogPath 代表.