### PR TITLE
change prom image

### DIFF
--- a/hack/contrib/docker/monitor/Dockerfile
+++ b/hack/contrib/docker/monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:v2.2.1
+FROM rainbond/prometheus:v2.2.1
 
 USER root
 VOLUME ["/prometheusdata"]


### PR DESCRIPTION
因为 ci 拉 prom/prometheus:v2.2.1 经常会失败, 所以改成 rainbond/prometheus:v2.2.1