### PR TITLE
create imagePullSecret for rainbond namespace

### DIFF
--- a/cmd/worker/option/option.go
+++ b/cmd/worker/option/option.go
@@ -54,7 +54,6 @@ type Config struct {
 	LeaderElectionIdentity  string
 	RBDNamespace            string
 	GrdataPVCName           string
-	RBDDNSName              string
 }
 
 //Worker  worker server
@@ -95,7 +94,6 @@ func (a *Worker) AddFlags(fs *pflag.FlagSet) {
 	flag.StringVar(&a.LeaderElectionIdentity, "leader-election-identity", "", "Unique idenity of this attcher. Typically name of the pod where the attacher runs.")
 	flag.StringVar(&a.RBDNamespace, "rbd-system-namespace", "rbd-system", "rbd components kubernetes namespace")
 	flag.StringVar(&a.GrdataPVCName, "grdata-pvc-name", "rbd-cpt-grdata", "The name of grdata persistent volume claim")
-	flag.StringVar(&a.RBDDNSName, "rbd-dns", "rbd-dns", "rbd dns endpoint name")
 }
 
 //SetLog 设置log

--- a/util/constants/constants.go
+++ b/util/constants/constants.go
@@ -5,4 +5,6 @@ const (
 	DefImageRepository = "goodrain.me"
 	// GrdataLogPath -
 	GrdataLogPath = "/grdata/logs"
+	// ImagePullSecretKey the key of environment IMAGE_PULL_SECRET
+	ImagePullSecretKey = "IMAGE_PULL_SECRET"
 )

--- a/worker/appm/conversion/service.go
+++ b/worker/appm/conversion/service.go
@@ -132,7 +132,8 @@ func initTenant(as *v1.AppService, tenant *dbmodel.Tenants) error {
 	}
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: tenant.UUID,
+			Name:   tenant.UUID,
+			Labels: map[string]string{"creator": "Rainbond"},
 		},
 	}
 	as.SetTenant(namespace)

--- a/worker/appm/conversion/version.go
+++ b/worker/appm/conversion/version.go
@@ -69,10 +69,11 @@ func TenantServiceVersion(as *v1.AppService, dbmanager db.Manager) error {
 			Name:        as.ServiceID + "-pod-spec",
 		},
 		Spec: corev1.PodSpec{
-			Volumes:      dv.GetVolumes(),
-			Containers:   []corev1.Container{*container},
-			NodeSelector: createNodeSelector(as, dbmanager),
-			Affinity:     createAffinity(as, dbmanager),
+			ImagePullSecrets: setImagePullSecrets(),
+			Volumes:          dv.GetVolumes(),
+			Containers:       []corev1.Container{*container},
+			NodeSelector:     createNodeSelector(as, dbmanager),
+			Affinity:         createAffinity(as, dbmanager),
 			Hostname: func() string {
 				if nodeID, ok := as.ExtensionSet["hostname"]; ok {
 					return nodeID
@@ -714,4 +715,15 @@ func createPodAnnotations(as *v1.AppService) map[string]string {
 		annotations["rainbond.com/tolerate-unready-endpoints"] = "true"
 	}
 	return annotations
+}
+
+func setImagePullSecrets() []corev1.LocalObjectReference {
+	imagePullSecretName := os.Getenv("IMAGE_PULL_SECRET")
+	if imagePullSecretName == "" {
+		return nil
+	}
+
+	return []corev1.LocalObjectReference{
+		{Name: imagePullSecretName},
+	}
 }

--- a/worker/appm/store/informer.go
+++ b/worker/appm/store/informer.go
@@ -24,6 +24,7 @@ import (
 
 //Informer kube-api client cache
 type Informer struct {
+	Namespace               cache.SharedIndexInformer
 	Ingress                 cache.SharedIndexInformer
 	Service                 cache.SharedIndexInformer
 	Secret                  cache.SharedIndexInformer
@@ -42,6 +43,7 @@ type Informer struct {
 
 //Start statrt
 func (i *Informer) Start(stop chan struct{}) {
+	go i.Namespace.Run(stop)
 	go i.Ingress.Run(stop)
 	go i.Service.Run(stop)
 	go i.Secret.Run(stop)
@@ -60,7 +62,7 @@ func (i *Informer) Start(stop chan struct{}) {
 
 //Ready if all kube informers is syncd, store is ready
 func (i *Informer) Ready() bool {
-	if i.Ingress.HasSynced() && i.Service.HasSynced() && i.Secret.HasSynced() &&
+	if i.Namespace.HasSynced() && i.Ingress.HasSynced() && i.Service.HasSynced() && i.Secret.HasSynced() &&
 		i.StatefulSet.HasSynced() && i.Deployment.HasSynced() && i.Pod.HasSynced() &&
 		i.ConfigMap.HasSynced() && i.Nodes.HasSynced() && i.Events.HasSynced() &&
 		i.HorizontalPodAutoscaler.HasSynced() && i.StorageClass.HasSynced() && i.Claims.HasSynced() {


### PR DESCRIPTION
支持带账号密码的 goodrain.me, 或其他镜像仓库. 作一下改动:

1. 用于源码构建的 Pod, 支持 ImagePullSecret.
2. 为每个 Rainbond 创建的 namespace, 都创建一个 ImagePullSecret, 在这个 namespace 下的 Pod, 都需要使用该 ImagePullSecret 去拉取镜像.