### PR TITLE
pull image runner

### DIFF
--- a/builder/sources/image.go
+++ b/builder/sources/image.go
@@ -365,6 +365,13 @@ func ImageBuild(dockerCli *client.Client, contextDir string, options types.Image
 	if err != nil {
 		return err
 	}
+
+	// pull image runner
+	if _, err := ImagePull(dockerCli, builder.RUNNERIMAGENAME, builder.REGISTRYUSER, builder.REGISTRYPASS, logger, timeout); err != nil {
+		return fmt.Errorf("pull image %s: %v", builder.RUNNERIMAGENAME, err)
+	}
+	logrus.Infof("pull image %s successfully.", builder.RUNNERIMAGENAME)
+
 	rc, err := dockerCli.ImageBuild(ctx, buildCtx, options)
 	if err != nil {
 		return err

--- a/builder/sources/image_test.go
+++ b/builder/sources/image_test.go
@@ -94,3 +94,4 @@ func TestImagePull(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+


### PR DESCRIPTION
源码构建时, runner 镜像可能不存在, 需要再构建前需要手动拉一下 runner