### PR TITLE
fix share plugin bugs

### DIFF
--- a/api/controller/plugin.go
+++ b/api/controller/plugin.go
@@ -616,10 +616,6 @@ func (t *TenantStruct) SharePlugin(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if sp.Body.ImageInfo.HubURL == "" || sp.Body.ImageInfo.Namespace == "" {
-		httputil.ReturnError(r, w, 400, "hub url or hub namespace can not be empty")
-		return
-	}
 	tenantID := r.Context().Value(middleware.ContextKey("tenant_id")).(string)
 	sp.TenantID = tenantID
 	sp.PluginID = chi.URLParam(r, "plugin_id")

--- a/api/handler/share/plugin_share.go
+++ b/api/handler/share/plugin_share.go
@@ -65,10 +65,10 @@ type PluginShare struct {
 		ShareUser     string `json:"share_user"`
 		ShareScope    string `json:"share_scope"`
 		ImageInfo     struct {
-			HubURL      string `json:"hub_url" validate:"hub_url|required"`
+			HubURL      string `json:"hub_url"`
 			HubUser     string `json:"hub_user"`
 			HubPassword string `json:"hub_password"`
-			Namespace   string `json:"namespace" validate:"namespace|required"`
+			Namespace   string `json:"namespace"`
 			IsTrust     bool   `json:"is_trust,omitempty" validate:"is_trust"`
 		} `json:"image_info,omitempty"`
 	}

--- a/builder/exector/share_plugin.go
+++ b/builder/exector/share_plugin.go
@@ -21,8 +21,9 @@ package exector
 import (
 	"context"
 	"fmt"
-	"github.com/goodrain/rainbond/builder"
 	"time"
+
+	"github.com/goodrain/rainbond/builder"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
@@ -84,10 +85,11 @@ func (i *PluginShareItem) Run(timeout time.Duration) error {
 		i.Logger.Error(fmt.Sprintf("修改镜像tag: %s -> %s 失败", i.LocalImageName, i.ImageName), map[string]string{"step": "builder-exector", "status": "failure"})
 		return err
 	}
+	user, pass := builder.GetImageUserInfo(i.ImageInfo.HubUser, i.ImageInfo.HubPassword)
 	if i.ImageInfo.IsTrust {
-		err = sources.TrustedImagePush(i.DockerClient, i.ImageName, i.ImageInfo.HubUser, i.ImageInfo.HubPassword, i.Logger, 10)
+		err = sources.TrustedImagePush(i.DockerClient, i.ImageName, user, pass, i.Logger, 10)
 	} else {
-		err = sources.ImagePush(i.DockerClient, i.ImageName, i.ImageInfo.HubUser, i.ImageInfo.HubPassword, i.Logger, 10)
+		err = sources.ImagePush(i.DockerClient, i.ImageName, user, pass, i.Logger, 10)
 	}
 	if err != nil {
 		if err.Error() == "authentication required" {


### PR DESCRIPTION
1、分享应用时推送插件到镜像仓库的账户密码处理，提供默认账户密码
2、去除rbd-api组件中分享插件时对账户密码参数的校验，默认不再提供该账户密码参数