### PR TITLE
update startup sequence

### DIFF
--- a/worker/appm/types/v1/v1.go
+++ b/worker/appm/types/v1/v1.go
@@ -118,12 +118,13 @@ type AppService struct {
 	pods        []*corev1.Pod
 	claims      []*corev1.PersistentVolumeClaim
 	// claims that needs to be created manually
-	claimsmanual   []*corev1.PersistentVolumeClaim
-	status         AppServiceStatus
-	Logger         event.Logger
-	storageClasses []*storagev1.StorageClass
-	UpgradePatch   map[string][]byte
-	CustomParams   map[string]string
+	claimsmanual     []*corev1.PersistentVolumeClaim
+	status           AppServiceStatus
+	BootSeqContainer *corev1.Container
+	Logger           event.Logger
+	storageClasses   []*storagev1.StorageClass
+	UpgradePatch     map[string][]byte
+	CustomParams     map[string]string
 }
 
 //CacheKey app cache key


### PR DESCRIPTION
问题：组件解除依赖后进行更新，新起的pod一直处于等待中。

解决：
1. 将启动顺序信息记录在 bootSequence 中。
2. 在更新时，如果旧的 deployment/statefulset 有启动顺序，则利用 bootSequence 去更新启动顺序，这时候会把不存在的依赖从启动顺序中去掉。