### PR TITLE
create or update certificate

### DIFF
--- a/api/handler/gateway_action.go
+++ b/api/handler/gateway_action.go
@@ -83,7 +83,7 @@ func (g *GatewayAction) AddHTTPRule(req *apimodel.AddHTTPRuleStruct) error {
 	}()
 	if err := db.GetManager().HTTPRuleDaoTransactions(tx).AddModel(httpRule); err != nil {
 		tx.Rollback()
-		return err
+		return fmt.Errorf("create http rule: %v", err)
 	}
 
 	if strings.Replace(req.CertificateID, " ", "", -1) != "" {
@@ -95,7 +95,7 @@ func (g *GatewayAction) AddHTTPRule(req *apimodel.AddHTTPRuleStruct) error {
 		}
 		if err := db.GetManager().CertificateDaoTransactions(tx).AddOrUpdate(cert); err != nil {
 			tx.Rollback()
-			return err
+			return fmt.Errorf("create or update http rule: %v", err)
 		}
 	}
 
@@ -108,14 +108,14 @@ func (g *GatewayAction) AddHTTPRule(req *apimodel.AddHTTPRuleStruct) error {
 		}
 		if err := db.GetManager().RuleExtensionDaoTransactions(tx).AddModel(re); err != nil {
 			tx.Rollback()
-			return err
+			return fmt.Errorf("create rule extensions: %v", err)
 		}
 	}
 
 	// end transaction
 	if err := tx.Commit().Error; err != nil {
 		tx.Rollback()
-		return err
+		return fmt.Errorf("commit transaction: %v", err)
 	}
 	// Effective immediately
 	if err := g.SendTask(map[string]interface{}{


### PR DESCRIPTION
修复更新或添加证书时的 bug。

`c.DB.Table(cert.TableName()).Where("uuid = ?", cert.UUID).Save(old)` 改成 `c.DB.Table(cert.TableName()).Where("uuid = ?", cert.UUID).Save(&old)`。

save 方法需要传入指针。