### PR TITLE
no longer check dynamic-lb

### DIFF
--- a/cmd/node/option/conf.go
+++ b/cmd/node/option/conf.go
@@ -70,6 +70,7 @@ type Conf struct {
 	LogFile                         string
 	HostID                          string
 	HostIP                          string
+	PodIP                           string
 	RunMode                         string //ACP_NODE 运行模式:master,node
 	NodeRule                        string //节点属性 compute manage storage
 	Service                         string //服务注册与发现
@@ -150,6 +151,7 @@ func (a *Conf) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.NodePath, "nodePath", "/rainbond/nodes", "the path of node in etcd")
 	fs.StringVar(&a.HostID, "nodeid", "", "the unique ID for this node. Just specify, don't modify")
 	fs.StringVar(&a.HostIP, "hostIP", "", "the host ip you can define. default get ip from eth0")
+	fs.StringVar(&a.PodIP, "podIP", "", "The pod ip of node.")
 	fs.StringSliceVar(&a.EventLogServer, "event-log-server", []string{"127.0.0.1:6366"}, "host:port slice of event log server")
 	fs.StringVar(&a.ConfigStoragePath, "config-path", "/rainbond/acp_configs", "the path of config to store(new)")
 	fs.StringVar(&a.Service, "servicePath", "/traefik/backends", "the path of service info to store")

--- a/node/api/manager.go
+++ b/node/api/manager.go
@@ -115,7 +115,7 @@ func (m *Manager) Start(errChan chan error) error {
 				return fmt.Errorf("get the api port info error.%s", err.Error())
 			}
 		}
-		keepalive, err := discover.CreateKeepAlive(m.etcdClientArgs, "acp_node", m.node.InternalIP, m.node.InternalIP, port)
+		keepalive, err := discover.CreateKeepAlive(m.etcdClientArgs, "acp_node", m.conf.PodIP, m.conf.PodIP, port)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
is-dynamic-lb-initialized 这个接口的作用是去检查内存中是否有 http 相关的 endpoints，当 gateway 没有任何 http server 的时候，则该接口不会返回 OK。
导致此时的网关健康检测不通过，实际上内存中没有 endpoints 不代表 gateway 不健康