### PR TITLE
proxy traffix to k8s dashboard

### DIFF
--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -181,6 +181,7 @@ func GetPodHandler() PodHandler {
 
 var defaultEtcdHandler *EtcdHandler
 
+// GetEtcdHandler returns the default etcd handler.
 func GetEtcdHandler() *EtcdHandler {
 	return defaultEtcdHandler
 }

--- a/api/handler/proxy.go
+++ b/api/handler/proxy.go
@@ -28,6 +28,7 @@ var nodeProxy proxy.Proxy
 var builderProxy proxy.Proxy
 var prometheusProxy proxy.Proxy
 var monitorProxy proxy.Proxy
+var kubernetesDashboard proxy.Proxy
 
 //InitProxy 初始化
 func InitProxy(conf option.Config) {
@@ -46,6 +47,9 @@ func InitProxy(conf option.Config) {
 	if monitorProxy == nil {
 		monitorProxy = proxy.CreateProxy("monitor", "http", []string{"127.0.0.1:3329"})
 		discover.GetEndpointDiscover().AddProject("monitor", monitorProxy)
+	}
+	if kubernetesDashboard == nil {
+		kubernetesDashboard = proxy.CreateProxy("kubernetesdashboard", "http", []string{conf.KuberentesDashboardAPI})
 	}
 }
 
@@ -67,4 +71,9 @@ func GetPrometheusProxy() proxy.Proxy {
 //GetMonitorProxy GetMonitorProxy
 func GetMonitorProxy() proxy.Proxy {
 	return monitorProxy
+}
+
+// GetKubernetesDashboardProxy returns the kubernetes dashboard proxy.
+func GetKubernetesDashboardProxy() proxy.Proxy {
+	return kubernetesDashboard
 }

--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -180,6 +180,13 @@ func Proxy(next http.Handler) http.Handler {
 			handler.GetMonitorProxy().Proxy(w, r)
 			return
 		}
+		if strings.HasPrefix(r.RequestURI, "/kubernetes/dashboard") {
+			logrus.Debugf("proxy traffic to kubernetes dashboard.")
+			proxy := handler.GetKubernetesDashboardProxy()
+			r.URL.Path = strings.Replace(r.URL.Path, "/kubernetes/dashboard", "", 1)
+			proxy.Proxy(w, r)
+			return
+		}
 		next.ServeHTTP(w, r)
 	}
 	return http.HandlerFunc(fn)

--- a/api/server/api.go
+++ b/api/server/api.go
@@ -151,6 +151,7 @@ func (m *Manager) Run() {
 	//兼容老版docker
 	m.r.Get("/v1/etcd/event-log/instances", m.EventLogInstance)
 
+	m.r.Get("/kubernetes/dashboard", m.KuberntesDashboardAPI)
 	//prometheus单节点代理
 	m.r.Get("/api/v1/query", m.PrometheusAPI)
 	m.r.Get("/api/v1/query_range", m.PrometheusAPI)
@@ -220,4 +221,9 @@ func (m *Manager) EventLogInstance(w http.ResponseWriter, r *http.Request) {
 //PrometheusAPI prometheus api 代理
 func (m *Manager) PrometheusAPI(w http.ResponseWriter, r *http.Request) {
 	handler.GetPrometheusProxy().Proxy(w, r)
+}
+
+// KuberntesDashboardAPI proxy traffix to kubernetes dashboard
+func (m *Manager) KuberntesDashboardAPI(w http.ResponseWriter, r *http.Request) {
+	handler.GetKubernetesDashboardProxy().Proxy(w, r)
 }

--- a/cmd/api/option/option.go
+++ b/cmd/api/option/option.go
@@ -27,36 +27,37 @@ import (
 
 //Config config
 type Config struct {
-	DBType            string
-	APIAddr           string
-	APIAddrSSL        string
-	DBConnectionInfo  string
-	EventLogServers   []string
-	NodeAPI           []string
-	BuilderAPI        []string
-	V1API             string
-	MQAPI             string
-	EtcdEndpoint      []string
-	EtcdCaFile        string
-	EtcdCertFile      string
-	EtcdKeyFile       string
-	APISSL            bool
-	APICertFile       string
-	APIKeyFile        string
-	APICaFile         string
-	WebsocketSSL      bool
-	WebsocketCertFile string
-	WebsocketKeyFile  string
-	WebsocketAddr     string
-	Opentsdb          string
-	RegionTag         string
-	LoggerFile        string
-	EnableFeature     []string
-	Debug             bool
-	MinExtPort        int // minimum external port
-	LicensePath       string
-	LicSoPath         string
-	LogPath           string
+	DBType                 string
+	APIAddr                string
+	APIAddrSSL             string
+	DBConnectionInfo       string
+	EventLogServers        []string
+	NodeAPI                []string
+	BuilderAPI             []string
+	V1API                  string
+	MQAPI                  string
+	EtcdEndpoint           []string
+	EtcdCaFile             string
+	EtcdCertFile           string
+	EtcdKeyFile            string
+	APISSL                 bool
+	APICertFile            string
+	APIKeyFile             string
+	APICaFile              string
+	WebsocketSSL           bool
+	WebsocketCertFile      string
+	WebsocketKeyFile       string
+	WebsocketAddr          string
+	Opentsdb               string
+	RegionTag              string
+	LoggerFile             string
+	EnableFeature          []string
+	Debug                  bool
+	MinExtPort             int // minimum external port
+	LicensePath            string
+	LicSoPath              string
+	LogPath                string
+	KuberentesDashboardAPI string
 }
 
 //APIServer  apiserver server
@@ -105,6 +106,7 @@ func (a *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.LicensePath, "license-path", "/opt/rainbond/etc/license/license.yb", "the license path of the enterprise version.")
 	fs.StringVar(&a.LicSoPath, "license-so-path", "/opt/rainbond/etc/license/license.so", "Dynamic library file path for parsing the license.")
 	fs.StringVar(&a.LogPath, "log-path", "/grdata/logs", "Where Docker log files and event log files are stored.")
+	fs.StringVar(&a.KuberentesDashboardAPI, "k8s-dashboard-api", "kubernetes-dashboard.kubernetes-dashboard:443", "The service DNS name of Kubernetes dashboard. Default to kubernetes-dashboard.kubernetes-dashboard")
 }
 
 //SetLog 设置log

--- a/cmd/api/option/option.go
+++ b/cmd/api/option/option.go
@@ -106,7 +106,7 @@ func (a *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.LicensePath, "license-path", "/opt/rainbond/etc/license/license.yb", "the license path of the enterprise version.")
 	fs.StringVar(&a.LicSoPath, "license-so-path", "/opt/rainbond/etc/license/license.so", "Dynamic library file path for parsing the license.")
 	fs.StringVar(&a.LogPath, "log-path", "/grdata/logs", "Where Docker log files and event log files are stored.")
-	fs.StringVar(&a.KuberentesDashboardAPI, "k8s-dashboard-api", "kubernetes-dashboard.kubernetes-dashboard:443", "The service DNS name of Kubernetes dashboard. Default to kubernetes-dashboard.kubernetes-dashboard")
+	fs.StringVar(&a.KuberentesDashboardAPI, "k8s-dashboard-api", "kubernetes-dashboard.rbd-system:443", "The service DNS name of Kubernetes dashboard. Default to kubernetes-dashboard.kubernetes-dashboard")
 }
 
 //SetLog 设置log


### PR DESCRIPTION
将路由开头是 `/kubernetes/dashboard` 的流量代理到 kubernetes dashboard 上。
dashboard 需要加上参数 `--enable-skip-login`。