### PR TITLE
add ProxyStreamResponses

### DIFF
--- a/gateway/controller/openresty/model/server.go
+++ b/gateway/controller/openresty/model/server.go
@@ -33,7 +33,14 @@ type Server struct {
 	Locations               []*Location
 	OptionValue             map[string]string
 	UpstreamName            string //used for tcp and udp server
-	ProxyStreamTimeout      string
+
+	// Sets the number of datagrams expected from the proxied server in response
+	// to the client request if the UDP protocol is used.
+	// http://nginx.org/en/docs/stream/ngx_stream_proxy_module.html#proxy_responses
+	// Default: 1
+	ProxyStreamResponses int
+
+	ProxyStreamTimeout string
 	//proxy protocol for tcp real ip
 	ProxyProtocol ProxyProtocol
 }

--- a/gateway/controller/openresty/service.go
+++ b/gateway/controller/openresty/service.go
@@ -243,7 +243,8 @@ func (o *OrService) getNgxServer(conf *v1.Config) (l7srv []*model.Server, l4srv 
 				"tenant_id":  vs.Namespace,
 				"service_id": vs.ServiceID,
 			},
-			UpstreamName: vs.PoolName,
+			UpstreamName:         vs.PoolName,
+			ProxyStreamResponses: 1,
 		}
 		server.Listen = strings.Join(vs.Listening, " ")
 		l4srv = append(l4srv, server)


### PR DESCRIPTION
添加参数 ProxyStreamResponses, 修复 udp 的网关策略问题:

```
can't evaluate field ProxyStreamResponses in type *model.Server
```