### PR TITLE
delete third party service

### DIFF
--- a/db/model/version.go
+++ b/db/model/version.go
@@ -39,7 +39,7 @@ type VersionInfo struct {
 	DeliveredType string `gorm:"column:delivered_type;size:40" json:"delivered_type"`  //kind
 	DeliveredPath string `gorm:"column:delivered_path;size:250" json:"delivered_path"` //交付物path
 	ImageName     string `gorm:"column:image_name;size:250" json:"image_name"`         //运行镜像名称
-	Cmd           string `gorm:"column:cmd;size:200" json:"cmd"`                       //启动命令
+	Cmd           string `gorm:"column:cmd;size:2048" json:"cmd"`                      //启动命令
 	RepoURL       string `gorm:"column:repo_url;size:2047" json:"repo_url"`
 	CodeVersion   string `gorm:"column:code_version;size:40" json:"code_version"`
 	CodeBranch    string `gorm:"column:code_branch;size:40" json:"code_branch"`

--- a/worker/gc/gc.go
+++ b/worker/gc/gc.go
@@ -106,6 +106,15 @@ func (g *GarbageCollector) DelKubernetesObjects(serviceGCReq model.ServiceGCTask
 	if err := g.clientset.CoreV1().Endpoints(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
 		logrus.Warningf("[DelKubernetesObjects] delete endpoints(%s): %v", serviceGCReq.ServiceID, err)
 	}
+	if err := g.clientset.CoreV1().Secrets(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
+		logrus.Warningf("[DelKubernetesObjects] delete secrets(%s): %v", serviceGCReq.ServiceID, err)
+	}
+	if err := g.clientset.CoreV1().ConfigMaps(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
+		logrus.Warningf("[DelKubernetesObjects] delete configmaps(%s): %v", serviceGCReq.ServiceID, err)
+	}
+	if err := g.clientset.AutoscalingV2beta2().HorizontalPodAutoscalers(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
+		logrus.Warningf("[DelKubernetesObjects] delete hpas(%s): %v", serviceGCReq.ServiceID, err)
+	}
 	// kubernetes does not support api for deleting collection of service
 	// read: https://github.com/kubernetes/kubernetes/issues/68468#issuecomment-419981870
 	serviceList, err := g.clientset.CoreV1().Services(serviceGCReq.TenantID).List(listOpts)

--- a/worker/gc/gc.go
+++ b/worker/gc/gc.go
@@ -103,9 +103,6 @@ func (g *GarbageCollector) DelKubernetesObjects(serviceGCReq model.ServiceGCTask
 	if err := g.clientset.ExtensionsV1beta1().Ingresses(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
 		logrus.Warningf("[DelKubernetesObjects] delete ingresses(%s): %v", serviceGCReq.ServiceID, err)
 	}
-	if err := g.clientset.CoreV1().Endpoints(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
-		logrus.Warningf("[DelKubernetesObjects] delete endpoints(%s): %v", serviceGCReq.ServiceID, err)
-	}
 	if err := g.clientset.CoreV1().Secrets(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
 		logrus.Warningf("[DelKubernetesObjects] delete secrets(%s): %v", serviceGCReq.ServiceID, err)
 	}
@@ -126,6 +123,10 @@ func (g *GarbageCollector) DelKubernetesObjects(serviceGCReq model.ServiceGCTask
 				logrus.Warningf("[DelKubernetesObjects] delete service(%s): %v", svc.GetName(), err)
 			}
 		}
+	}
+	// delete endpoints after deleting services
+	if err := g.clientset.CoreV1().Endpoints(serviceGCReq.TenantID).DeleteCollection(deleteOpts, listOpts); err != nil {
+		logrus.Warningf("[DelKubernetesObjects] delete endpoints(%s): %v", serviceGCReq.ServiceID, err)
 	}
 }
 

--- a/worker/handle/manager.go
+++ b/worker/handle/manager.go
@@ -492,6 +492,7 @@ func (m *Manager) ExecServiceGCTask(task *model.Task) error {
 	m.garbageCollector.DelLogFile(serviceGCReq)
 	m.garbageCollector.DelPvPvcByServiceID(serviceGCReq)
 	m.garbageCollector.DelVolumeData(serviceGCReq)
+	m.garbageCollector.DelKubernetesObjects(serviceGCReq)
 	return nil
 }
 


### PR DESCRIPTION
删除组件的同时，删除相关的 k8s 对象，包括：deployment，statefulset，ingress，service，endpoint。
避免组件删除后，还有残留的，游离的  k8s 对象。