### PR TITLE
Build error

### DIFF
--- a/cmd/node/server/client.go
+++ b/cmd/node/server/client.go
@@ -141,7 +141,7 @@ func upgradeImages(ctx *cli.Context) error {
 			if util.StringArrayContains(ctx.StringSlice("s"), service.Name) &&
 				service.Start != "" && !service.OnlyHealthCheck {
 				par := parser.CreateDockerRunOrImageParse("", "", service.Start, nil, event.GetTestLogger())
-				par.ParseDockerun(strings.Split(service.Start, " "))
+				par.ParseDockerun(service.Start)
 				image := par.GetImage()
 				if image.Name == "" {
 					continue

--- a/node/nodem/controller/manager_service.go
+++ b/node/nodem/controller/manager_service.go
@@ -529,7 +529,7 @@ func (m *ManagerService) ListServiceImages() []string {
 		}
 
 		par := parser.CreateDockerRunOrImageParse("", "", svc.Start, nil, event.GetTestLogger())
-		par.ParseDockerun(strings.Split(svc.Start, " "))
+		par.ParseDockerun(svc.Start)
 		logrus.Debugf("detect image: %s", par.GetImage().String())
 		if par.GetImage().String() == "" {
 			continue


### PR DESCRIPTION
fix `node/nodem/controller/manager_service.go:532:34: cannot use strings.Split(svc.Start, " ") (type []string) as type string in argument to par.ParseDockerun`