### PR TITLE
Bug Fix: failed to check old version images

### DIFF
--- a/builder/parser/docker_compose.go
+++ b/builder/parser/docker_compose.go
@@ -195,7 +195,7 @@ func (d *DockerComposeParse) Parse() ParseErrorList {
 		d.logger.Debug(fmt.Sprintf("start check service %s ", service.name), map[string]string{"step": "service_check", "status": "running"})
 		exist, err := sources.ImageExist(service.image.String(), hubUser, hubPass)
 		if err != nil {
-			logrus.Errorf("check image exist failure %s", err.Error())
+			logrus.Errorf("check image(%s) exist failure %s", service.image.String(), err.Error())
 		}
 		if !exist {
 			d.errappend(ErrorAndSolve(FatalError, fmt.Sprintf("服务%s镜像%s检测失败", serviceName, service.image.String()), SolveAdvice("modify_compose", fmt.Sprintf("请确认%s服务镜像名称是否正确或镜像仓库访问是否正常", serviceName))))

--- a/builder/sources/registry.go
+++ b/builder/sources/registry.go
@@ -19,8 +19,9 @@
 package sources
 
 import (
+	"fmt"
+	
 	"github.com/goodrain/rainbond/builder/sources/registry"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/reference"
 )
@@ -67,9 +68,8 @@ func ImageExist(imageName, user, password string) (bool, error) {
 			}
 		}
 		tag := GetTagFromNamedRef(name)
-		_, err = reg.ManifestV2(reference.Path(name), tag)
-		if err != nil {
-			rerr = err
+		if err := reg.CheckManifest(reference.Path(name), tag); err != nil {
+			rerr = fmt.Errorf("[ImageExist] check manifest v2: %v", err)
 			continue
 		}
 		return true, nil

--- a/builder/sources/registry/manifest.go
+++ b/builder/sources/registry/manifest.go
@@ -20,14 +20,17 @@ package registry
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/Sirupsen/logrus"
 	manifestV1 "github.com/docker/distribution/manifest/schema1"
 	manifestV2 "github.com/docker/distribution/manifest/schema2"
 	digest "github.com/opencontainers/go-digest"
 )
 
+// Manifest -
 func (registry *Registry) Manifest(repository, reference string) (*manifestV1.SignedManifest, error) {
 	url := registry.url("/v2/%s/manifests/%s", repository, reference)
 	registry.Logf("registry.manifest.get url=%s repository=%s reference=%s", url, repository, reference)
@@ -58,9 +61,10 @@ func (registry *Registry) Manifest(repository, reference string) (*manifestV1.Si
 	return signedManifest, nil
 }
 
+// ManifestV2 -
 func (registry *Registry) ManifestV2(repository, reference string) (*manifestV2.DeserializedManifest, error) {
 	url := registry.url("/v2/%s/manifests/%s", repository, reference)
-	registry.Logf("registry.manifest.get url=%s repository=%s reference=%s", url, repository, reference)
+	logrus.Debugf("registry.manifest.get url=%s repository=%s reference=%s", url, repository, reference)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -70,7 +74,7 @@ func (registry *Registry) ManifestV2(repository, reference string) (*manifestV2.
 	req.Header.Set("Accept", manifestV2.MediaTypeManifest)
 	resp, err := registry.Client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("do request: %v", err)
 	}
 
 	defer resp.Body.Close()
@@ -82,11 +86,25 @@ func (registry *Registry) ManifestV2(repository, reference string) (*manifestV2.
 	deserialized := &manifestV2.DeserializedManifest{}
 	err = deserialized.UnmarshalJSON(body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal JSON: %v", err)
 	}
 	return deserialized, nil
 }
 
+// CheckManifest checks if the manifest of the given image is exist.
+func (registry *Registry) CheckManifest(repository, reference string) error {
+	url := registry.url("/v2/%s/manifests/%s", repository, reference)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = registry.Client.Do(req)
+	return err
+}
+
+// ManifestDigest -
 func (registry *Registry) ManifestDigest(repository, reference string) (digest.Digest, error) {
 	url := registry.url("/v2/%s/manifests/%s", repository, reference)
 	registry.Logf("registry.manifest.head url=%s repository=%s reference=%s", url, repository, reference)
@@ -101,6 +119,7 @@ func (registry *Registry) ManifestDigest(repository, reference string) (digest.D
 	return digest.Parse(resp.Header.Get("Docker-Content-Digest"))
 }
 
+// DeleteManifest -
 func (registry *Registry) DeleteManifest(repository string, digest digest.Digest) error {
 	url := registry.url("/v2/%s/manifests/%s", repository, digest)
 	registry.Logf("registry.manifest.delete url=%s repository=%s reference=%s", url, repository, digest)
@@ -119,6 +138,7 @@ func (registry *Registry) DeleteManifest(repository string, digest digest.Digest
 	return nil
 }
 
+// PutManifest -
 func (registry *Registry) PutManifest(repository, reference string, signedManifest *manifestV1.SignedManifest) error {
 	url := registry.url("/v2/%s/manifests/%s", repository, reference)
 	registry.Logf("registry.manifest.put url=%s repository=%s reference=%s", url, repository, reference)


### PR DESCRIPTION
bug detail: 
Failed to check old version images, such as `prom/pushgateway:v0.3.1`, `prom/prometheus:v2.2.1`, which use outdated schema1 manifest format. 
But `ManifestV2` expects schema2 manifest format.

solutions:
`CheckManifest` will ignore the schema version of the image manifest, and just check if it exists.