### PR TITLE
Bug Fix: circular dependency

### DIFF
--- a/cmd/init-probe/healthy/depends_health.go
+++ b/cmd/init-probe/healthy/depends_health.go
@@ -78,12 +78,7 @@ func NewDependServiceHealthController() (*DependServiceHealthController, error) 
 	}
 	dsc.endpointClient = v2.NewEndpointDiscoveryServiceClient(cli)
 	dsc.clusterClient = v2.NewClusterDiscoveryServiceClient(cli)
-	nameIDs := strings.Split(os.Getenv("DEPEND_SERVICE"), ",")
-	for _, nameID := range nameIDs {
-		if len(strings.Split(nameID, ":")) > 0 {
-			dsc.dependServiceNames = append(dsc.dependServiceNames, strings.Split(nameID, ":")[0])
-		}
-	}
+	dsc.dependServiceNames = strings.Split(os.Getenv("STARTUP_SEQUENCE_DEPENDENCIES"), ",")
 	return &dsc, nil
 }
 


### PR DESCRIPTION
Bug detail:
circular dependency, causing components to fail to start

Solutions:
Use ServiceDependency to maintain the dependencies between components. If a circular dependency is found, cancel one of the dependencies, such as: change A->B->C->A to A->B->C.