### PR TITLE
Bug Fix: bad argument #1 to 'pairs' (table expected, got nil)

### DIFF
--- a/gateway/store/store.go
+++ b/gateway/store/store.go
@@ -690,7 +690,6 @@ func (s *k8sStore) ListVirtualService() (l7vs []*v1.VirtualService, l4vs []*v1.V
 
 // ingressIsValid checks if the specified ingress is valid
 func (s *k8sStore) ingressIsValid(ing *extensions.Ingress) bool {
-
 	var endpointKey string
 	if ing.Spec.Backend != nil { // stream
 		endpointKey = fmt.Sprintf("%s/%s", ing.Namespace, ing.Spec.Backend.ServiceName)
@@ -724,7 +723,7 @@ func (s *k8sStore) ingressIsValid(ing *extensions.Ingress) bool {
 		return false
 	}
 	for _, ep := range endpoint.Subsets {
-		if (ep.Addresses == nil || len(ep.Addresses) == 0) && (ep.NotReadyAddresses == nil || len(ep.NotReadyAddresses) == 0) {
+		if len(ep.Addresses) == 0 {
 			logrus.Debugf("Endpoints(%s) is empty, ignore it", endpointKey)
 			return false
 		}

--- a/gateway/store/store.go
+++ b/gateway/store/store.go
@@ -718,18 +718,25 @@ func (s *k8sStore) ingressIsValid(ing *extensions.Ingress) bool {
 		logrus.Errorf("Cant not convert %v to %v", reflect.TypeOf(item), reflect.TypeOf(endpoint))
 		return false
 	}
-	if endpoint.Subsets == nil || len(endpoint.Subsets) == 0 {
+	if len(endpoint.Subsets) == 0 {
 		logrus.Debugf("Endpoints(%s) is empty, ignore it", endpointKey)
 		return false
 	}
-	for _, ep := range endpoint.Subsets {
-		if len(ep.Addresses) == 0 {
-			logrus.Debugf("Endpoints(%s) is empty, ignore it", endpointKey)
-			return false
-		}
+	if !hasReadyAddresses(endpoint) {
+		logrus.Debugf("Endpoints(%s) is empty, ignore it", endpointKey)
+		return false
 	}
 
 	return true
+}
+
+func hasReadyAddresses(endpoints *corev1.Endpoints) bool {
+	for _, ep := range endpoints.Subsets {
+		if len(ep.Addresses) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // GetIngress returns the Ingress matching key.


### PR DESCRIPTION
Bug details:

```
2020/10/22 09:46:44 [error] 9008#9008: init_worker_by_lua error: /run/nginx/lua/util.lua:12: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
 [C]: in function 'pairs'
 /run/nginx/lua/util.lua:12: in function 'get_nodes'
 /run/nginx/lua/balancer/round_robin.lua:8: in function 'new'
 /run/nginx/lua/balancer.lua:59: in function 'sync_backend'
 /run/nginx/lua/balancer.lua:91: in function 'sync_backends'
 /run/nginx/lua/balancer.lua:103: in function 'init_worker'
 init_worker_by_lua:2: in main chunk
```

If the ingress has not ready endpoints, so the backend is nil. But util.lua expected table, not nil.

Solutions:
Ignore the ingresses that have no ready endpoints.