### PR TITLE
bug fix: wrong app cpu and memory

### DIFF
--- a/worker/appm/store/store.go
+++ b/worker/appm/store/store.go
@@ -1412,7 +1412,7 @@ func (a *appRuntimeStore) GetAppResources(appID string) (int64, int64, error) {
 		return 0, 0, err
 	}
 	selector := labels.NewSelector()
-	selector.Add(*requirement)
+	selector = selector.Add(*requirement)
 	pods, err := a.listers.Pod.List(selector)
 	if err != nil {
 		return 0, 0, err


### PR DESCRIPTION
bug detail:

The application uses CPU and memory statistics error.  The application's CPU and memory statistics are wrong. The reason is that the return value of selector.Add(*requirement) is not received. 

solutions:

Receive the return value of xxx, update selector
