### PR TITLE
Fix Bug: The config group created the variable in the inactive state

### DIFF
--- a/api/handler/application_config_group.go
+++ b/api/handler/application_config_group.go
@@ -63,6 +63,7 @@ func (a *ApplicationAction) AddConfigGroup(appID string, req *model.ApplicationC
 		AppID:           appID,
 		ConfigGroupName: req.ConfigGroupName,
 		DeployType:      req.DeployType,
+		Enable:          req.Enable,
 	}
 	if err := db.GetManager().AppConfigGroupDaoTransactions(tx).AddModel(config); err != nil {
 		tx.Rollback()
@@ -93,6 +94,7 @@ func (a *ApplicationAction) AddConfigGroup(appID string, req *model.ApplicationC
 		DeployType:      appconfig.DeployType,
 		ConfigItems:     configGroupItems,
 		Services:        configGroupServices,
+		Enable:          appconfig.Enable,
 	}
 	return resp, nil
 }
@@ -172,6 +174,7 @@ func (a *ApplicationAction) UpdateConfigGroup(appID, configGroupName string, req
 		DeployType:      appconfig.DeployType,
 		ConfigItems:     configGroupItems,
 		Services:        configGroupServices,
+		Enable:          appconfig.Enable,
 	}
 	return resp, nil
 }
@@ -222,6 +225,7 @@ func (a *ApplicationAction) ListConfigGroups(appID string, page, pageSize int) (
 			AppID:           c.AppID,
 			ConfigGroupName: c.ConfigGroupName,
 			DeployType:      c.DeployType,
+			Enable:          c.Enable,
 		}
 
 		configGroupServices, err := db.GetManager().AppConfigGroupServiceDao().GetConfigGroupServicesByID(c.AppID, c.ConfigGroupName)

--- a/api/handler/application_config_group.go
+++ b/api/handler/application_config_group.go
@@ -118,6 +118,7 @@ func (a *ApplicationAction) UpdateConfigGroup(appID, configGroupName string, req
 		}
 	}()
 	// Update effective status
+	appconfig.Enable = req.Enable
 	if err := db.GetManager().AppConfigGroupDaoTransactions(tx).UpdateModel(appconfig); err != nil {
 		tx.Rollback()
 		return nil, err

--- a/api/handler/application_config_group.go
+++ b/api/handler/application_config_group.go
@@ -117,6 +117,11 @@ func (a *ApplicationAction) UpdateConfigGroup(appID, configGroupName string, req
 			tx.Rollback()
 		}
 	}()
+	// Update effective status
+	if err := db.GetManager().AppConfigGroupDaoTransactions(tx).UpdateModel(appconfig); err != nil {
+		tx.Rollback()
+		return nil, err
+	}
 	// Update application configGroup-services
 	if err := db.GetManager().AppConfigGroupServiceDaoTransactions(tx).DeleteConfigGroupService(appID, configGroupName); err != nil {
 		tx.Rollback()

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -1697,6 +1697,7 @@ type ApplicationConfigGroup struct {
 	DeployType      string       `json:"deploy_type" validate:"required,oneof=env configfile"`
 	ServiceIDs      []string     `json:"service_ids"`
 	ConfigItems     []ConfigItem `json:"config_items"`
+	Enable          bool         `json:"enable"`
 }
 
 // ApplicationConfigGroupResp -
@@ -1707,12 +1708,14 @@ type ApplicationConfigGroupResp struct {
 	DeployType      string                        `json:"deploy_type"`
 	Services        []*dbmodel.ConfigGroupService `json:"services"`
 	ConfigItems     []*dbmodel.ConfigGroupItem    `json:"config_items"`
+	Enable          bool                          `json:"enable"`
 }
 
 // UpdateAppConfigGroupReq -
 type UpdateAppConfigGroupReq struct {
 	ServiceIDs  []string     `json:"service_ids"`
 	ConfigItems []ConfigItem `json:"config_items" validate:"required"`
+	Enable      bool         `json:"enable"`
 }
 
 // ListApplicationConfigGroupResp -

--- a/db/model/application.go
+++ b/db/model/application.go
@@ -60,6 +60,7 @@ type ApplicationConfigGroup struct {
 	AppID           string `gorm:"column:app_id" json:"app_id"`
 	ConfigGroupName string `gorm:"column:config_group_name" json:"config_group_name"`
 	DeployType      string `gorm:"column:deploy_type;default:'env'" json:"deploy_type"`
+	Enable          bool   `gorm:"column:enable" json:"enable"`
 }
 
 // TableName return tableName "application"

--- a/db/mysql/dao/application_config_group.go
+++ b/db/mysql/dao/application_config_group.go
@@ -27,9 +27,7 @@ func (a *AppConfigGroupDaoImpl) AddModel(mo model.Interface) error {
 //UpdateModel -
 func (a *AppConfigGroupDaoImpl) UpdateModel(mo model.Interface) error {
 	updateReq := mo.(*model.ApplicationConfigGroup)
-	return a.DB.Model(&model.ApplicationConfigGroup{}).
-		Where("app_id = ? AND config_group_name = ?", updateReq.AppID, updateReq.ConfigGroupName.
-			Update("enable", updateReq.Enable).Error
+	return a.DB.Model(&model.ApplicationConfigGroup{}).Where("app_id = ? AND config_group_name = ?", updateReq.AppID, updateReq.ConfigGroupName).Update("enable", updateReq.Enable).Error
 }
 
 // GetConfigGroupByID -

--- a/db/mysql/dao/application_config_group.go
+++ b/db/mysql/dao/application_config_group.go
@@ -26,7 +26,10 @@ func (a *AppConfigGroupDaoImpl) AddModel(mo model.Interface) error {
 
 //UpdateModel -
 func (a *AppConfigGroupDaoImpl) UpdateModel(mo model.Interface) error {
-	return nil
+	updateReq := mo.(*model.ApplicationConfigGroup)
+	return a.DB.Model(&model.ApplicationConfigGroup{}).
+		Where("app_id = ? AND config_group_name = ?", updateReq.AppID, updateReq.ConfigGroupName.
+			Update("enable", updateReq.Enable).Error
 }
 
 // GetConfigGroupByID -
@@ -40,7 +43,7 @@ func (a *AppConfigGroupDaoImpl) GetConfigGroupByID(appID, configGroupName string
 
 func (a *AppConfigGroupDaoImpl) ListByServiceID(sid string) ([]*model.ApplicationConfigGroup, error) {
 	var groups []*model.ApplicationConfigGroup
-	if err := a.DB.Model(model.ApplicationConfigGroup{}).Select("app_config_group.*").Joins("left join app_config_group_service on app_config_group.app_id = app_config_group_service.app_id and app_config_group.config_group_name = app_config_group_service.config_group_name").
+	if err := a.DB.Debug().Model(model.ApplicationConfigGroup{}).Select("app_config_group.*").Joins("left join app_config_group_service on app_config_group.app_id = app_config_group_service.app_id and app_config_group.config_group_name = app_config_group_service.config_group_name").
 		Where("app_config_group_service.service_id = ? and enable = true", sid).Scan(&groups).Error; err != nil {
 		return nil, err
 	}

--- a/db/mysql/dao/application_config_group.go
+++ b/db/mysql/dao/application_config_group.go
@@ -41,7 +41,7 @@ func (a *AppConfigGroupDaoImpl) GetConfigGroupByID(appID, configGroupName string
 func (a *AppConfigGroupDaoImpl) ListByServiceID(sid string) ([]*model.ApplicationConfigGroup, error) {
 	var groups []*model.ApplicationConfigGroup
 	if err := a.DB.Model(model.ApplicationConfigGroup{}).Select("app_config_group.*").Joins("left join app_config_group_service on app_config_group.app_id = app_config_group_service.app_id and app_config_group.config_group_name = app_config_group_service.config_group_name").
-		Where("app_config_group_service.service_id = ?", sid).Scan(&groups).Error; err != nil {
+		Where("app_config_group_service.service_id = ? and enable = true", sid).Scan(&groups).Error; err != nil {
 		return nil, err
 	}
 	return groups, nil

--- a/db/mysql/dao/application_config_group.go
+++ b/db/mysql/dao/application_config_group.go
@@ -41,7 +41,7 @@ func (a *AppConfigGroupDaoImpl) GetConfigGroupByID(appID, configGroupName string
 
 func (a *AppConfigGroupDaoImpl) ListByServiceID(sid string) ([]*model.ApplicationConfigGroup, error) {
 	var groups []*model.ApplicationConfigGroup
-	if err := a.DB.Debug().Model(model.ApplicationConfigGroup{}).Select("app_config_group.*").Joins("left join app_config_group_service on app_config_group.app_id = app_config_group_service.app_id and app_config_group.config_group_name = app_config_group_service.config_group_name").
+	if err := a.DB.Model(model.ApplicationConfigGroup{}).Select("app_config_group.*").Joins("left join app_config_group_service on app_config_group.app_id = app_config_group_service.app_id and app_config_group.config_group_name = app_config_group_service.config_group_name").
 		Where("app_config_group_service.service_id = ? and enable = true", sid).Scan(&groups).Error; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- The config group created the variable in the inactive state
solution: use the effective state as a field in the region，Only valid app config groups are created