### PR TITLE
Fix Bug: commit msg too long 

### DIFF
--- a/db/model/version.go
+++ b/db/model/version.go
@@ -43,7 +43,7 @@ type VersionInfo struct {
 	RepoURL       string `gorm:"column:repo_url;size:2047" json:"repo_url"`
 	CodeVersion   string `gorm:"column:code_version;size:40" json:"code_version"`
 	CodeBranch    string `gorm:"column:code_branch;size:40" json:"code_branch"`
-	CommitMsg     string `gorm:"column:code_commit_msg;size:200" json:"code_commit_msg"`
+	CommitMsg     string `gorm:"column:code_commit_msg;size:65535" json:"code_commit_msg"`
 	Author        string `gorm:"column:code_commit_author;size:40" json:"code_commit_author"`
 	//FinalStatus app version status
 	//success: version available

--- a/db/model/version.go
+++ b/db/model/version.go
@@ -43,7 +43,7 @@ type VersionInfo struct {
 	RepoURL       string `gorm:"column:repo_url;size:2047" json:"repo_url"`
 	CodeVersion   string `gorm:"column:code_version;size:40" json:"code_version"`
 	CodeBranch    string `gorm:"column:code_branch;size:40" json:"code_branch"`
-	CommitMsg     string `gorm:"column:code_commit_msg;size:65535" json:"code_commit_msg"`
+	CommitMsg     string `gorm:"column:code_commit_msg;size:1024" json:"code_commit_msg"`
 	Author        string `gorm:"column:code_commit_author;size:40" json:"code_commit_author"`
 	//FinalStatus app version status
 	//success: version available

--- a/db/mysql/dao/version.go
+++ b/db/mysql/dao/version.go
@@ -50,8 +50,8 @@ func (c *VersionInfoDaoImpl) DeleteVersionByServiceID(serviceID string) error {
 //AddModel AddModel
 func (c *VersionInfoDaoImpl) AddModel(mo model.Interface) error {
 	result := mo.(*model.VersionInfo)
-	if len(result.CommitMsg) > 200 {
-		result.CommitMsg = result.CommitMsg[:200]
+	if len(result.CommitMsg) > 1024 {
+		result.CommitMsg = result.CommitMsg[:1024]
 	}
 	var oldResult model.VersionInfo
 	if ok := c.DB.Where("build_version=? and service_id=?", result.BuildVersion, result.ServiceID).Find(&oldResult).RecordNotFound(); ok {
@@ -66,6 +66,9 @@ func (c *VersionInfoDaoImpl) AddModel(mo model.Interface) error {
 //UpdateModel UpdateModel
 func (c *VersionInfoDaoImpl) UpdateModel(mo model.Interface) error {
 	result := mo.(*model.VersionInfo)
+	if len(result.CommitMsg) > 1024 {
+		result.CommitMsg = result.CommitMsg[:1024]
+	}
 	if err := c.DB.Save(result).Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
- The commit message is too long and failed to be stored in the database
Solution: Modify database column restrictions，reference resources: https://stackoverflow.com/questions/9733757/maximum-commit-message-size, So limit length is 65535.