### PR TITLE
Bug Fix: components get redundant gateway metrics

### DIFF
--- a/cmd/gateway/server/server.go
+++ b/cmd/gateway/server/server.go
@@ -87,7 +87,11 @@ func Run(s *option.GWServer) error {
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(prometheus.NewGoCollector())
-	reg.MustRegister(prometheus.NewProcessCollector(os.Getpid(), "gateway"))
+	reg.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{
+		PidFn: func() (int, error) {
+			return os.Getpid(), nil
+		},
+	}))
 	mc := metric.NewDummyCollector()
 	if s.Config.EnableMetrics {
 		mc, err = metric.NewCollector(s.NodeName, reg)

--- a/gateway/controller/openresty/nginxcmd/nginx_cmd.go
+++ b/gateway/controller/openresty/nginxcmd/nginx_cmd.go
@@ -34,15 +34,15 @@ var (
 	//ErrorCheck check config file failure
 	ErrorCheck  = fmt.Errorf("error check config")
 	updateCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "gateway",
+		Namespace: "nginx",
 		Subsystem: "",
-		Name:      "nginx_update",
+		Name:      "update",
 		Help:      "Number of nginx updates inside the gateway",
 	})
 	errUpdateCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "gateway",
+		Namespace: "nginx",
 		Subsystem: "",
-		Name:      "nginx_update_err",
+		Name:      "update_err",
 		Help:      "Number of nginx error updates inside the gateway",
 	})
 )

--- a/gateway/metric/collectors/controller.go
+++ b/gateway/metric/collectors/controller.go
@@ -39,7 +39,7 @@ func NewController() *Controller {
 	cm := &Controller{
 		activeDomain: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Namespace:   PrometheusNamespace,
+				Namespace:   "nginx",
 				Name:        "active_server",
 				Help:        "Cumulative number of active server",
 				ConstLabels: constLabels,


### PR DESCRIPTION
### Bug Detail

All metrics in gateway have a namespace 'gateway', unable to classify various metrics

### Solutions

1. 不再统一用 ‘gateway’ 作为命名空间。查询的时候加上 job=gateway，来区分 gateway 的指标。
2. 组件级别的指标保留命名空间 gateway，以后就已 gateway 作为组件的标识，因为组件级的指标都在用
3. 其他类型的指标，比如 process, nginx，都改掉了，这些指标目前是没有在使用的。

