### PR TITLE
Bug Fix: two service for thirdparty service

### DIFF
--- a/worker/appm/conversion/conversion.go
+++ b/worker/appm/conversion/conversion.go
@@ -110,6 +110,16 @@ func InitCacheAppService(dbm db.Manager, serviceID, creatorID string) (*v1.AppSe
 		},
 		UpgradePatch: make(map[string][]byte, 2),
 	}
+
+	// setup governance mode
+	app, err := dbm.ApplicationDao().GetByServiceID(serviceID)
+	if err != nil && err != bcode.ErrApplicationNotFound {
+		return nil, fmt.Errorf("get app based on service id(%s)", serviceID)
+	}
+	if app != nil {
+		appService.AppServiceBase.GovernanceMode = app.GovernanceMode
+	}
+
 	if err := TenantServiceBase(appService, dbm); err != nil {
 		return nil, err
 	}

--- a/worker/appm/conversion/gateway.go
+++ b/worker/appm/conversion/gateway.go
@@ -148,9 +148,9 @@ func (a *AppServiceBuild) Build() (*v1.K8sResources, error) {
 			port := ports[i]
 			if *port.IsInnerService {
 				if a.appService.GovernanceMode == model.GovernanceModeBuildInServiceMesh {
-					services = append(services, a.createKubernetesNativeService(port))
-				} else {
 					services = append(services, a.createInnerService(port))
+				} else {
+					services = append(services, a.createKubernetesNativeService(port))
 				}
 			}
 			if *port.IsOuterService {

--- a/worker/appm/thirdparty/thirdparty.go
+++ b/worker/appm/thirdparty/thirdparty.go
@@ -238,8 +238,8 @@ func (t *thirdparty) k8sEndpoints(as *v1.AppService, epinfo []*v1.RbdEndpoint) (
 		return nil, err
 	}
 	// third-party service can only have one port
-	if ports == nil || len(ports) == 0 {
-		return nil, fmt.Errorf("Port not found")
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("port not found")
 	}
 	p := ports[0]
 
@@ -250,6 +250,9 @@ func (t *thirdparty) k8sEndpoints(as *v1.AppService, epinfo []*v1.RbdEndpoint) (
 		// inner or outer
 		if *p.IsInnerService {
 			ep.Name = fmt.Sprintf("service-%d-%d", p.ID, p.ContainerPort)
+			if p.K8sServiceName != "" {
+				ep.Name = p.K8sServiceName
+			}
 			ep.Labels = as.GetCommonLabels(map[string]string{
 				"name":         as.ServiceAlias + "Service",
 				"service-kind": model.ServiceKindThirdParty.String(),


### PR DESCRIPTION
有两个地方创建第三方组件的 service：
1. 操作端口，域名等属性
2. worker 启动时，会为所有对内对外端口创建 service

第一点的 AppService 已经增加了 governance mode，但是第二点没有；所以两种方式创建出来的 service 会不一样，所以会创建两个 service。

另外，根据 governance mode 创建 inner service 还是 k8s service 的条件反了。

最后，endpoints 名字与 service 保持一致，如果 k8s_service_name 为空，则使用 `fmt.Sprintf("service-%d-%d", p.ID, p.ContainerPort)`；否则直接使用 k8s_service_name