### PR TITLE
New Feature: ignore nodes for rainbondsslc

### DIFF
--- a/worker/appm/store/resource.go
+++ b/worker/appm/store/resource.go
@@ -21,7 +21,6 @@ package store
 import (
 	"sync"
 
-	"github.com/Sirupsen/logrus"
 	v1 "github.com/goodrain/rainbond/worker/appm/types/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -74,7 +73,6 @@ func (r *ResourceCache) SetPodResource(pod *corev1.Pod) {
 		nameR.SetPodResource(pod.Name, re)
 		r.resources[namespace] = &nameR
 	}
-	logrus.Debugf("set namespace %s pod %s resource", namespace, pod.Name)
 }
 
 //RemovePod remove pod resource

--- a/worker/master/volumes/provider/rainbondsslc_test.go
+++ b/worker/master/volumes/provider/rainbondsslc_test.go
@@ -36,7 +36,7 @@ func TestSelectNode(t *testing.T) {
 		name:    "rainbond.io/provisioner-sslc",
 		kubecli: client,
 	}
-	node, err := pr.selectNode("linux")
+	node, err := pr.selectNode("linux", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/worker/master/volumes/provider/rainbondsssc.go
+++ b/worker/master/volumes/provider/rainbondsssc.go
@@ -55,6 +55,8 @@ var _ controller.Provisioner = &rainbondssscProvisioner{}
 
 // Provision creates a storage asset and returns a PV object representing it.
 func (p *rainbondssscProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
+	logrus.Debugf("[rainbondssscProvisioner] start creating PV object. paramters: %+v", options.Parameters)
+
 	tenantID := options.PVC.Labels["tenant_id"]
 	serviceID := options.PVC.Labels["service_id"]
 	_, stateless := options.PVC.Labels["stateless"]


### PR DESCRIPTION
Use the field 'parameters' to define which nodes rainbondsslc will ignore.

For example:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: rainbondslsc
provisioner: rainbond.io/provisioner-sslc
parameters:
  ignoreNodes: foo,bar
reclaimPolicy: Retain
volumeBindingMode: Immediate
```

rainbondsslc will never schedule any PV to nodes foo and bar