### PR TITLE
Bug Fix: Extra service appears when restarting worker

### DIFF
--- a/api/middleware/middleware.go
+++ b/api/middleware/middleware.go
@@ -264,6 +264,7 @@ func WrapEL(f http.HandlerFunc, target, optType string, synType int) http.Handle
 			//eventLog check the latest event
 
 			if !util.CanDoEvent(optType, synType, target, targetID) {
+				logrus.Errorf("operation too frequently. uri: %s; target: %s; target id: %s", r.RequestURI, target, targetID)
 				httputil.ReturnError(r, w, 409, "操作过于频繁，请稍后再试") // status code 409 conflict
 				return
 			}

--- a/worker/appm/conversion/conversion.go
+++ b/worker/appm/conversion/conversion.go
@@ -104,9 +104,10 @@ func InitAppService(dbmanager db.Manager, serviceID string, configs map[string]s
 func InitCacheAppService(dbm db.Manager, serviceID, creatorID string) (*v1.AppService, error) {
 	appService := &v1.AppService{
 		AppServiceBase: v1.AppServiceBase{
-			ServiceID:    serviceID,
-			CreaterID:    creatorID,
-			ExtensionSet: make(map[string]string),
+			ServiceID:      serviceID,
+			CreaterID:      creatorID,
+			ExtensionSet:   make(map[string]string),
+			GovernanceMode: model.GovernanceModeBuildInServiceMesh,
 		},
 		UpgradePatch: make(map[string][]byte, 2),
 	}

--- a/worker/appm/conversion/gateway.go
+++ b/worker/appm/conversion/gateway.go
@@ -147,10 +147,11 @@ func (a *AppServiceBuild) Build() (*v1.K8sResources, error) {
 		for i := range ports {
 			port := ports[i]
 			if *port.IsInnerService {
-				if a.appService.GovernanceMode == model.GovernanceModeBuildInServiceMesh {
-					services = append(services, a.createInnerService(port))
-				} else {
+				switch a.appService.GovernanceMode {
+				case model.GovernanceModeKubernetesNativeService:
 					services = append(services, a.createKubernetesNativeService(port))
+				default:
+					services = append(services, a.createInnerService(port))
 				}
 			}
 			if *port.IsOuterService {


### PR DESCRIPTION
### Bug Detail
The GovernanceMode of the old application maybe "", that is, it is not BuildInServiceMesh, nor KubernetesNativeService. As long as the condition of a.appService.GovernanceMode == model.GovernanceModeBuildInServiceMesh is not met, the service will be created using createKubernetesNativeService.

### Solutions

Make GovernanceModeBuildInServiceMesh as default governance mode.