### PR TITLE
拓扑图加载缓慢问题

### DIFF
--- a/api/handler/service.go
+++ b/api/handler/service.go
@@ -1931,14 +1931,6 @@ func (s *ServiceAction) GetMultiServicePods(serviceIDs []string) (*K8sPodInfos, 
 			podInfo.PodIP = v.PodIp
 			podInfo.PodStatus = v.PodStatus
 			podInfo.ServiceID = serviceID
-			containerInfos := make(map[string]map[string]string, 10)
-			for _, container := range v.Containers {
-				containerInfos[container.ContainerName] = map[string]string{
-					"memory_limit": fmt.Sprintf("%d", container.MemoryLimit),
-					"memory_usage": "0",
-				}
-			}
-			podInfo.Container = containerInfos
 			podNames = append(podNames, v.PodName)
 			podsInfoList = append(podsInfoList, &podInfo)
 		}

--- a/api/handler/service.go
+++ b/api/handler/service.go
@@ -1942,14 +1942,6 @@ func (s *ServiceAction) GetMultiServicePods(serviceIDs []string) (*K8sPodInfos, 
 			podNames = append(podNames, v.PodName)
 			podsInfoList = append(podsInfoList, &podInfo)
 		}
-		containerMemInfo, _ := s.GetPodContainerMemory(podNames)
-		for _, c := range podsInfoList {
-			for k := range c.Container {
-				if info, exist := containerMemInfo[c.PodName][k]; exist {
-					c.Container[k]["memory_usage"] = info
-				}
-			}
-		}
 		return podsInfoList
 	}
 	var re K8sPodInfos


### PR DESCRIPTION
Refer to: #947

拓扑图加载慢是因为每个组件的实例数的计算慢.

组件的实例数是根据组件的 pods 数量计算的, 而获取多个组件实例的接口比较慢. 因为该接口会在一个 for 循环里去获取pod内存的使用情况.

获取多个组件pods的接口里是不需要统计内存使用情况的, 获取单个组件pods才需要.

所以, 我把for循环获取内存使用情况的逻辑去掉了.