### PR TITLE
Fix Bug: the error message when the application backup is performed 

### DIFF
--- a/api/handler/group/group_backup.go
+++ b/api/handler/group/group_backup.go
@@ -238,15 +238,8 @@ func (h *BackupHandle) snapshot(ids []string, sourceDir string, force bool) erro
 		}
 		status := h.statusCli.GetStatus(id)
 		logrus.Debugf("service: %s is state: %v", service.ServiceAlias, service.IsState())
-		if !force && status != v1.CLOSED && service.IsState() { // state running service force backup
-			versions, err := db.GetManager().VersionInfoDao().GetVersionByServiceID(id)
-			if err != nil {
-				logrus.Errorf("Get component version error when backing up components: %v", err)
-				return err
-			}
-			if len(versions) > 0 {
-				return fmt.Errorf("state app must be closed before backup")
-			}
+		if !force && status != v1.CLOSED && status != v1.UNDEPLOY && service.IsState() { // state running service force backup
+			return fmt.Errorf("state app must be closed before backup")
 		}
 		data.ServiceStatus = status
 		data.Service = service

--- a/api/handler/group/group_backup.go
+++ b/api/handler/group/group_backup.go
@@ -239,7 +239,14 @@ func (h *BackupHandle) snapshot(ids []string, sourceDir string, force bool) erro
 		status := h.statusCli.GetStatus(id)
 		logrus.Debugf("service: %s is state: %v", service.ServiceAlias, service.IsState())
 		if !force && status != v1.CLOSED && service.IsState() { // state running service force backup
-			return fmt.Errorf("state app must be closed before backup")
+			versions, err := db.GetManager().VersionInfoDao().GetVersionByServiceID(id)
+			if err != nil {
+				logrus.Errorf("Get component version error when backing up components: %v", err)
+				return err
+			}
+			if len(versions) > 0 {
+				return fmt.Errorf("state app must be closed before backup")
+			}
 		}
 		data.ServiceStatus = status
 		data.Service = service


### PR DESCRIPTION
- When the stateful component is not deployed, the backup application will give an error message that the component is not closed. Therefore, this error is ignored when the component has no deployment version.