### PR TITLE
Bug Fix: successThreshold for liveness must be 1

### DIFF
--- a/worker/appm/conversion/version.go
+++ b/worker/appm/conversion/version.go
@@ -561,7 +561,7 @@ func createPorts(as *v1.AppService, dbmanager db.Manager) (ports []corev1.Contai
 func createProbe(as *v1.AppService, dbmanager db.Manager, mode string) *corev1.Probe {
 	probe, err := dbmanager.ServiceProbeDao().GetServiceUsedProbe(as.ServiceID, mode)
 	if err == nil && probe != nil {
-		if mode == "liveness" && probe.SuccessThreshold < 1 {
+		if mode == "liveness" {
 			probe.SuccessThreshold = 1
 		}
 		if mode == "readiness" && probe.FailureThreshold < 1 {


### PR DESCRIPTION
### Detail

spec.template.spec.containers[0].livenessProbe.successThreshold: Invalid value: 2: must be 1

### Solution

set successThreshold to 1 for liveness

refer to: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/