### PR TITLE
Bug Fix: timeout service event

### DIFF
--- a/api/controller/event.go
+++ b/api/controller/event.go
@@ -24,12 +24,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jinzhu/gorm"
-
 	"github.com/bitly/go-simplejson"
 	"github.com/go-chi/chi"
+	"github.com/goodrain/rainbond/api/handler"
 	"github.com/goodrain/rainbond/db"
 	httputil "github.com/goodrain/rainbond/util/http"
+	"github.com/jinzhu/gorm"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,18 +59,20 @@ func (t *TenantStruct) Event(w http.ResponseWriter, r *http.Request) {
 		httputil.ReturnError(r, w, 400, "bad request")
 		return
 	}
-	eventIDS, err := j.Get("event_ids").StringArray()
+	eventIDs, err := j.Get("event_ids").StringArray()
 	if err != nil {
 		logrus.Errorf("error get event_id in json,details %s", err.Error())
 		httputil.ReturnError(r, w, 400, "bad request")
 		return
 	}
-	serviceEvents, err := db.GetManager().ServiceEventDao().GetEventByEventIDs(eventIDS)
+
+	events, err := handler.GetServiceEventHandler().ListByEventIDs(eventIDs)
 	if err != nil {
-		logrus.Warnf("can't find event by given id ,details %s", err.Error())
-		httputil.ReturnError(r, w, 500, err.Error())
+		httputil.ReturnBcodeError(r, w, err)
+		return
 	}
-	httputil.ReturnSuccess(r, w, serviceEvents)
+
+	httputil.ReturnSuccess(r, w, events)
 }
 
 //GetNotificationEvents GetNotificationEvent

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -67,5 +67,17 @@ func (s *ServiceEventHandler) isTimeout(event *dbmodel.ServiceEvent) bool {
 		return false
 	}
 
-	return time.Now().After(startTime.Add(5 * time.Minute))
+	if event.OptType == "deploy" || event.OptType == "create" || event.OptType == "build" || event.OptType == "upgrade" {
+		end := startTime.Add(3 * time.Minute)
+		if time.Now().After(end) {
+			return true
+		}
+	} else {
+		end := startTime.Add(30 * time.Second)
+		if time.Now().After(end) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/api/handler/event.go
+++ b/api/handler/event.go
@@ -19,97 +19,53 @@
 package handler
 
 import (
-	"fmt"
-
-	"github.com/jinzhu/gorm"
-
 	"time"
 
 	"github.com/goodrain/rainbond/db"
 	dbmodel "github.com/goodrain/rainbond/db/model"
-	tutil "github.com/goodrain/rainbond/util"
 	"github.com/sirupsen/logrus"
 )
 
-//TIMELAYOUT timelayout
-const TIMELAYOUT = "2006-01-02T15:04:05"
-
-//ErrEventIsRuning  last event is running
-var ErrEventIsRuning = fmt.Errorf("event is running")
-
-//ErrEventIDIsExist event id is exist
-var ErrEventIDIsExist = fmt.Errorf("event_id is exist")
-
-func createEvent(eventID, serviceID, optType, tenantID string) (*dbmodel.ServiceEvent, error) {
-	if eventID == "" {
-		eventID = tutil.NewUUID()
-	}
-	event := dbmodel.ServiceEvent{}
-	event.EventID = eventID
-	event.ServiceID = serviceID
-	event.OptType = optType
-	event.TenantID = tenantID
-	now := time.Now()
-	timeNow := now.Format(TIMELAYOUT)
-	event.StartTime = timeNow
-	event.UserName = "system"
-	events, err := db.GetManager().ServiceEventDao().GetEventByServiceID(serviceID)
-	if err != nil && err.Error() != gorm.ErrRecordNotFound.Error() {
-		return nil, err
-	}
-	err = checkCanAddEvent(serviceID, event.EventID, events)
-	if err != nil {
-		logrus.Errorf("error check event %s", err.Error())
-		return nil, err
-	}
-	if err := db.GetManager().ServiceEventDao().AddModel(&event); err != nil {
-		return nil, err
-	}
-	return &event, nil
+// ServiceEventHandler -
+type ServiceEventHandler struct {
 }
 
-func checkCanAddEvent(serviceID, eventID string, existEvents []*dbmodel.ServiceEvent) error {
-	if len(existEvents) == 0 {
-		return nil
-	}
-	latestEvent := existEvents[0]
-	if latestEvent.EventID == eventID {
-		return ErrEventIDIsExist
-	}
-	if latestEvent.FinalStatus == "" {
-		//未完成
-		timeOut, err := checkEventTimeOut(latestEvent)
-		if err != nil {
-			return err
-		}
-		logrus.Debugf("event %s timeOut %v", latestEvent.EventID, timeOut)
-		if timeOut {
-			return nil
-		}
-		return ErrEventIsRuning
-	}
-	return nil
+// NewServiceEventHandler -
+func NewServiceEventHandler() *ServiceEventHandler {
+	return &ServiceEventHandler{}
 }
-func checkEventTimeOut(event *dbmodel.ServiceEvent) (bool, error) {
-	startTime := event.StartTime
-	start, err := time.ParseInLocation(TIMELAYOUT, startTime, time.Local)
+
+// ListByEventIDs -
+func (s *ServiceEventHandler) ListByEventIDs(eventIDs []string) ([]*dbmodel.ServiceEvent, error) {
+	events, err := db.GetManager().ServiceEventDao().GetEventByEventIDs(eventIDs)
 	if err != nil {
-		return true, err
+		return nil, err
 	}
-	if event.OptType == "deploy" || event.OptType == "create" || event.OptType == "build" || event.OptType == "upgrade" {
-		end := start.Add(3 * time.Minute)
-		if time.Now().After(end) {
-			event.FinalStatus = "timeout"
-			err = db.GetManager().ServiceEventDao().UpdateModel(event)
-			return true, err
+
+	// timeout events
+	var timeoutEvents []*dbmodel.ServiceEvent
+	for _, event := range events {
+		if !s.isTimeout(event) {
+			continue
 		}
-	} else {
-		end := start.Add(30 * time.Second)
-		if time.Now().After(end) {
-			event.FinalStatus = "timeout"
-			err = db.GetManager().ServiceEventDao().UpdateModel(event)
-			return true, err
-		}
+		event.Status = "timeout"
+		event.FinalStatus = "complete"
+		timeoutEvents = append(timeoutEvents, event)
 	}
-	return false, nil
+
+	return events, db.GetManager().ServiceEventDao().UpdateInBatch(timeoutEvents)
+}
+
+func (s *ServiceEventHandler) isTimeout(event *dbmodel.ServiceEvent) bool {
+	if event.FinalStatus != "" {
+		return false
+	}
+
+	startTime, err := time.ParseInLocation(time.RFC3339, event.StartTime, time.Local)
+	if err != nil {
+		logrus.Errorf("[ServiceEventHandler] [isTimeout] parse start time(%s): %v", event.StartTime, err)
+		return false
+	}
+
+	return time.Now().After(startTime.Add(5 * time.Minute))
 }

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -81,6 +81,7 @@ func InitHandle(conf option.Config,
 	defaultEtcdHandler = NewEtcdHandler(etcdcli)
 	defaultmonitorHandler = NewMonitorHandler(prometheusCli)
 	defApplicationHandler = NewApplicationHandler(statusCli, prometheusCli)
+	defServiceEventHandler = NewServiceEventHandler()
 	return nil
 }
 
@@ -219,4 +220,11 @@ var defApplicationHandler ApplicationHandler
 // GetApplicationHandler  returns the default tenant application handler.
 func GetApplicationHandler() ApplicationHandler {
 	return defApplicationHandler
+}
+
+var defServiceEventHandler *ServiceEventHandler
+
+// GetServiceEventHandler -
+func GetServiceEventHandler() *ServiceEventHandler {
+	return defServiceEventHandler
 }

--- a/db/dao/dao.go
+++ b/db/dao/dao.go
@@ -428,6 +428,7 @@ type EventDao interface {
 	LatestFailurePodEvent(podName string) (*model.ServiceEvent, error)
 	UpdateReason(eventID string, reason string) error
 	SetEventStatus(ctx context.Context, status model.EventStatus) error
+	UpdateInBatch(events []*model.ServiceEvent) error
 }
 
 //VersionInfoDao VersionInfoDao


### PR DESCRIPTION
### Bug Detail

When an event timeout, if the next task is not initiated, then this time will never timeout.

### Solution

When getting the event list, if the time exceeds 5 minutes, the event is set to timeout.

eg. remove used function `createEvent`, `checkCanAddEvent` and `checkEventTimeOut`.