### PR TITLE
Bug Fix: use affinity insteand of node name

### DIFF
--- a/worker/appm/conversion/version.go
+++ b/worker/appm/conversion/version.go
@@ -738,10 +738,10 @@ func createAffinity(as *v1.AppService, dbmanager db.Manager) *corev1.Affinity {
 			Operator: corev1.NodeSelectorOpIn,
 		})
 	}
-	if nodeName, ok := as.ExtensionSet["selecthost"]; ok {
+	if hostname, ok := as.ExtensionSet["selecthost"]; ok {
 		nsr = append(nsr, corev1.NodeSelectorRequirement{
 			Key:      "kubernetes.io/hostname",
-			Values:   []string{nodeName},
+			Values:   []string{hostname},
 			Operator: corev1.NodeSelectorOpIn,
 		})
 	}

--- a/worker/appm/conversion/version.go
+++ b/worker/appm/conversion/version.go
@@ -94,6 +94,12 @@ func TenantServiceVersion(as *v1.AppService, dbmanager db.Manager) error {
 				}
 				return ""
 			}(),
+			NodeName: func() string {
+				if nodeID, ok := as.ExtensionSet["selectnode"]; ok {
+					return nodeID
+				}
+				return ""
+			}(),
 			HostNetwork: func() bool {
 				if _, ok := as.ExtensionSet["hostnetwork"]; ok {
 					return true
@@ -732,7 +738,7 @@ func createAffinity(as *v1.AppService, dbmanager db.Manager) *corev1.Affinity {
 			Operator: corev1.NodeSelectorOpIn,
 		})
 	}
-	if nodeName, ok := as.ExtensionSet["selectnode"]; ok {
+	if nodeName, ok := as.ExtensionSet["selecthost"]; ok {
 		nsr = append(nsr, corev1.NodeSelectorRequirement{
 			Key:      "kubernetes.io/hostname",
 			Values:   []string{nodeName},

--- a/worker/appm/conversion/version.go
+++ b/worker/appm/conversion/version.go
@@ -94,12 +94,6 @@ func TenantServiceVersion(as *v1.AppService, dbmanager db.Manager) error {
 				}
 				return ""
 			}(),
-			NodeName: func() string {
-				if nodeID, ok := as.ExtensionSet["selectnode"]; ok {
-					return nodeID
-				}
-				return ""
-			}(),
 			HostNetwork: func() bool {
 				if _, ok := as.ExtensionSet["hostnetwork"]; ok {
 					return true
@@ -735,6 +729,13 @@ func createAffinity(as *v1.AppService, dbmanager db.Manager) *corev1.Affinity {
 		nsr = append(nsr, corev1.NodeSelectorRequirement{
 			Key:      client.LabelGPU,
 			Values:   []string{"true"},
+			Operator: corev1.NodeSelectorOpIn,
+		})
+	}
+	if nodeName, ok := as.ExtensionSet["selectnode"]; ok {
+		nsr = append(nsr, corev1.NodeSelectorRequirement{
+			Key:      "kubernetes.io/hostname",
+			Values:   []string{nodeName},
 			Operator: corev1.NodeSelectorOpIn,
 		})
 	}


### PR DESCRIPTION
### Detail

![image](https://user-images.githubusercontent.com/21967570/124708195-80f49600-df2c-11eb-9e11-717a45a2acbd.png)

Using ES_SELECTNODE and local storage at the same time is equivalent to using WaitForFirstConsumer and nodeName at the same time, which will cause the PVC to not be tied to the PV.

### Solution

Kubernetes is not allowed to use WaitForFirstConsumer and nodeName together:
![image](https://user-images.githubusercontent.com/21967570/124708917-7c7cad00-df2d-11eb-82df-b199a71ea518.png)
More detail [here](https://kubernetes.io/docs/concepts/storage/storage-classes/)

So, I change nodeName to node selector. It's fine to make this change, because their function is the same