### PR TITLE
Bug Fix: set header is not working

### DIFF
--- a/api/model/gateway_model.go
+++ b/api/model/gateway_model.go
@@ -173,8 +173,8 @@ type Body struct {
 
 //SetHeader set header
 type SetHeader struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string `json:"item_key"`
+	Value string `json:"item_value"`
 }
 
 // Rewrite is a embeded sturct of Body.


### PR DESCRIPTION
### Bug Detail

set header for gateway rule is not working.

![image](https://user-images.githubusercontent.com/21967570/125010983-31cc7380-e09a-11eb-8f2a-d0d6365fdd88.png)

The key and value of the header should be `key` and `value` which are designed at the beginning. 

![image](https://user-images.githubusercontent.com/21967570/125010857-f16cf580-e099-11eb-8bd3-52d04a53c42d.png)

But the key and value of the header in the front-end are `item_key` and `item_value`.

![image](https://user-images.githubusercontent.com/21967570/125011358-e1094a80-e09a-11eb-8400-1aea760eb17d.png)

The key and value of the header in the console are also `item_key` and `item_value`.

### Solution

For minimal changes, I change the key and value in rainbond to `item_key` and `item_value` for matching the ones in the front-end or console.

