### PR TITLE
Opitimization: upgrade ingress from extensions to networking

### DIFF
--- a/gateway/annotations/annotations.go
+++ b/gateway/annotations/annotations.go
@@ -32,7 +32,7 @@ import (
 	"github.com/goodrain/rainbond/util/ingress-nginx/ingress/errors"
 	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -74,7 +74,7 @@ func NewAnnotationExtractor(cfg resolver.Resolver) Extractor {
 }
 
 // Extract extracts the annotations from an Ingress
-func (e Extractor) Extract(ing *extensions.Ingress) *Ingress {
+func (e Extractor) Extract(ing *networkingv1.Ingress) *Ingress {
 	pia := &Ingress{
 		ObjectMeta: ing.ObjectMeta,
 	}

--- a/gateway/annotations/cookie/cookie.go
+++ b/gateway/annotations/cookie/cookie.go
@@ -21,10 +21,11 @@ package cookie
 import (
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"strings"
 )
 
+// Config -
 type Config struct {
 	Cookie map[string]string `json:"cookie"`
 }
@@ -33,11 +34,12 @@ type cookie struct {
 	r resolver.Resolver
 }
 
+// NewParser -
 func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return cookie{r}
 }
 
-func (c cookie) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (c cookie) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	co, err := parser.GetStringAnnotation("cookie", ing)
 	if err != nil {
 		return nil, err

--- a/gateway/annotations/cookie/cookie_test.go
+++ b/gateway/annotations/cookie/cookie_test.go
@@ -20,18 +20,18 @@ package cookie
 
 import (
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
+func buildIngress() *networkingv1.Ingress {
 	defaultBackend := extensions.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networkingv1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/gateway/annotations/header/header.go
+++ b/gateway/annotations/header/header.go
@@ -21,10 +21,11 @@ package header
 import (
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"strings"
 )
 
+// Config -
 type Config struct {
 	Header map[string]string `json:"header"`
 }
@@ -33,11 +34,12 @@ type header struct {
 	r resolver.Resolver
 }
 
+// NewParser -
 func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return header{r}
 }
 
-func (h header) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (h header) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	hr, err := parser.GetStringAnnotation("header", ing)
 	if err != nil {
 		return nil, err

--- a/gateway/annotations/header/header_test.go
+++ b/gateway/annotations/header/header_test.go
@@ -20,18 +20,18 @@ package header
 
 import (
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
+func buildIngress() *networkingv1.Ingress {
 	defaultBackend := extensions.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networkingv1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/gateway/annotations/l4/l4.go
+++ b/gateway/annotations/l4/l4.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
+// Config -
 type Config struct {
 	L4Enable bool
 	L4Host   string
@@ -35,11 +36,12 @@ type l4 struct {
 	r resolver.Resolver
 }
 
+// NewParser -
 func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return l4{r}
 }
 
-func (l l4) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (l l4) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	l4Enable, _ := parser.GetBoolAnnotation("l4-enable", ing)
 	l4Host, _ := parser.GetStringAnnotation("l4-host", ing)
 	if l4Host == "" {

--- a/gateway/annotations/l4/l4_test.go
+++ b/gateway/annotations/l4/l4_test.go
@@ -20,18 +20,18 @@ package l4
 
 import (
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func buildIngress() *extensions.Ingress {
+func buildIngress() *networkingv1.Ingress {
 	defaultBackend := extensions.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networkingv1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/gateway/annotations/lbtype/lbtype.go
+++ b/gateway/annotations/lbtype/lbtype.go
@@ -21,7 +21,7 @@ package lbtype
 import (
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 type lbtype struct {
@@ -36,6 +36,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a lbtype) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a lbtype) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("lb-type", ing)
 }

--- a/gateway/annotations/parser/parser.go
+++ b/gateway/annotations/parser/parser.go
@@ -22,8 +22,7 @@ import (
 	"strings"
 
 	"github.com/goodrain/rainbond/util/ingress-nginx/ingress/errors"
-
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 var (
@@ -33,7 +32,7 @@ var (
 
 // IngressAnnotation has a method to parse annotations located in Ingress
 type IngressAnnotation interface {
-	Parse(ing *extensions.Ingress) (interface{}, error)
+	Parse(ing *networkingv1.Ingress) (interface{}, error)
 }
 
 type ingAnnotations map[string]string
@@ -70,7 +69,7 @@ func (a ingAnnotations) parseInt(name string) (int, error) {
 	return 0, errors.ErrMissingAnnotations
 }
 
-func checkAnnotation(name string, ing *extensions.Ingress) error {
+func checkAnnotation(name string, ing *networkingv1.Ingress) error {
 	if ing == nil || len(ing.GetAnnotations()) == 0 {
 		return errors.ErrMissingAnnotations
 	}
@@ -82,7 +81,7 @@ func checkAnnotation(name string, ing *extensions.Ingress) error {
 }
 
 // GetBoolAnnotation extracts a boolean from an Ingress annotation
-func GetBoolAnnotation(name string, ing *extensions.Ingress) (bool, error) {
+func GetBoolAnnotation(name string, ing *networkingv1.Ingress) (bool, error) {
 	v := GetAnnotationWithPrefix(name)
 	err := checkAnnotation(v, ing)
 	if err != nil {
@@ -92,7 +91,7 @@ func GetBoolAnnotation(name string, ing *extensions.Ingress) (bool, error) {
 }
 
 // GetStringAnnotation extracts a string from an Ingress annotation
-func GetStringAnnotation(name string, ing *extensions.Ingress) (string, error) {
+func GetStringAnnotation(name string, ing *networkingv1.Ingress) (string, error) {
 	v := GetAnnotationWithPrefix(name)
 	err := checkAnnotation(v, ing)
 	if err != nil {
@@ -102,7 +101,7 @@ func GetStringAnnotation(name string, ing *extensions.Ingress) (string, error) {
 }
 
 // GetIntAnnotation extracts an int from an Ingress annotation
-func GetIntAnnotation(name string, ing *extensions.Ingress) (int, error) {
+func GetIntAnnotation(name string, ing *networkingv1.Ingress) (int, error) {
 	v := GetAnnotationWithPrefix(name)
 	err := checkAnnotation(v, ing)
 	if err != nil {
@@ -113,7 +112,7 @@ func GetIntAnnotation(name string, ing *extensions.Ingress) (int, error) {
 
 // GetStringAnnotationWithPrefix extracts an string from an Ingress annotation
 // based on the annotation prefix
-func GetStringAnnotationWithPrefix(prefix string, ing *extensions.Ingress) (map[string]string, error) {
+func GetStringAnnotationWithPrefix(prefix string, ing *networkingv1.Ingress) (map[string]string, error) {
 	v := GetAnnotationWithPrefix(prefix)
 	err := checkAnnotation(v, ing)
 	if err != nil {

--- a/gateway/annotations/parser/parser_test.go
+++ b/gateway/annotations/parser/parser_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func buildIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func buildIngress() *networkingv1.Ingress {
+	return &networkingv1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/gateway/annotations/proxy/proxy.go
+++ b/gateway/annotations/proxy/proxy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/goodrain/rainbond/gateway/controller/config"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/http/httpguts"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 // Config returns the proxy timeout to use in the upstream server/s
@@ -191,7 +191,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to configure upstream check parameters
-func (a proxy) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a proxy) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	defBackend := a.r.GetDefaultBackend()
 	config := &Config{}
 

--- a/gateway/annotations/proxy/proxy_test.go
+++ b/gateway/annotations/proxy/proxy_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -29,13 +29,13 @@ import (
 	"github.com/goodrain/rainbond/gateway/defaults"
 )
 
-func buildIngress() *extensions.Ingress {
+func buildIngress() *networkingv1.Ingress {
 	defaultBackend := extensions.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networkingv1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/gateway/annotations/rewrite/rewrite.go
+++ b/gateway/annotations/rewrite/rewrite.go
@@ -22,7 +22,7 @@ import (
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
 	"github.com/sirupsen/logrus"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 // Config describes the per location redirect config
@@ -85,7 +85,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to rewrite the defined paths
-func (a rewrite) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a rewrite) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	var err error
 	config := &Config{}
 

--- a/gateway/annotations/rewrite/rewrite_test.go
+++ b/gateway/annotations/rewrite/rewrite_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -32,13 +32,13 @@ const (
 	defRoute = "/demo"
 )
 
-func buildIngress() *extensions.Ingress {
+func buildIngress() *networkingv1.Ingress {
 	defaultBackend := extensions.IngressBackend{
 		ServiceName: "default-backend",
 		ServicePort: intstr.FromInt(80),
 	}
 
-	return &extensions.Ingress{
+	return &networkingv1.Ingress{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: api.NamespaceDefault,

--- a/gateway/annotations/upstreamhashby/main.go
+++ b/gateway/annotations/upstreamhashby/main.go
@@ -19,7 +19,7 @@ package upstreamhashby
 import (
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 type upstreamhashby struct {
@@ -34,6 +34,6 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to indicate if the location/s contains a fragment of
 // configuration to be included inside the paths of the rules
-func (a upstreamhashby) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (a upstreamhashby) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	return parser.GetStringAnnotation("upstream-hash-by", ing)
 }

--- a/gateway/annotations/wight/weight.go
+++ b/gateway/annotations/wight/weight.go
@@ -22,7 +22,7 @@ import (
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	"github.com/goodrain/rainbond/gateway/annotations/resolver"
 	"github.com/sirupsen/logrus"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"strconv"
 )
 
@@ -40,7 +40,7 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 	return weight{r}
 }
 
-func (c weight) Parse(ing *extensions.Ingress) (interface{}, error) {
+func (c weight) Parse(ing *networkingv1.Ingress) (interface{}, error) {
 	wstr, err := parser.GetStringAnnotation("weight", ing)
 	var w int
 	if err != nil || wstr == "" {

--- a/gateway/store/secret_ingress_map.go
+++ b/gateway/store/secret_ingress_map.go
@@ -22,14 +22,14 @@ import (
 	"fmt"
 
 	"github.com/goodrain/rainbond/util/ingress-nginx/k8s"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 type secretIngressMap struct {
 	v map[string][]string
 }
 
-func (m *secretIngressMap) update(ing *v1beta1.Ingress) {
+func (m *secretIngressMap) update(ing *networkingv1.Ingress) {
 	ingKey := k8s.MetaNamespaceKey(ing)
 	for _, tls := range ing.Spec.TLS {
 		secretKey := fmt.Sprintf("%s/%s", ing.Namespace, tls.SecretName)

--- a/gateway/store/store_test.go
+++ b/gateway/store/store_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -60,8 +60,8 @@ func TestRbdStore_checkIngress(t *testing.T) {
 	}
 }
 
-func buildIngress() *extensions.Ingress {
-	return &extensions.Ingress{
+func buildIngress() *networkingv1.Ingress {
+	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foobar",
 			Namespace: api.NamespaceDefault,

--- a/gateway/test/http/http_test.go
+++ b/gateway/test/http/http_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/goodrain/rainbond/gateway/controller"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	api_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,23 +126,27 @@ func TestHttpDefault(t *testing.T) {
 	_ = ensureService(service, clientSet, t)
 	time.Sleep(3 * time.Second)
 
-	ingress := &extensions.Ingress{
+	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default-ing",
 			Namespace: ns.Name,
 		},
-		Spec: extensions.IngressSpec{
-			Rules: []extensions.IngressRule{
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: "www.http-router.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
 									Path: "/http-router",
-									Backend: extensions.IngressBackend{
-										ServiceName: "default-svc",
-										ServicePort: intstr.FromInt(80),
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "default-svc",
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
 									},
 								},
 							},
@@ -229,7 +233,7 @@ func TestHttpCookie(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	ingress := &extensions.Ingress{
+	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "router-cookie-ing",
 			Namespace: ns.Name,
@@ -237,18 +241,22 @@ func TestHttpCookie(t *testing.T) {
 				parser.GetAnnotationWithPrefix("cookie"): "ck1:cv1;ck2:cv2;",
 			},
 		},
-		Spec: extensions.IngressSpec{
-			Rules: []extensions.IngressRule{
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: "www.http-router.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
 									Path: "/http-router",
-									Backend: extensions.IngressBackend{
-										ServiceName: "router-cookie-svc",
-										ServicePort: intstr.FromInt(80),
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "router-cookie-svc",
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
 									},
 								},
 							},
@@ -338,7 +346,7 @@ func TestHttpHeader(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	ingress := &extensions.Ingress{
+	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "router-header-ing",
 			Namespace: ns.Name,
@@ -346,18 +354,22 @@ func TestHttpHeader(t *testing.T) {
 				parser.GetAnnotationWithPrefix("header"): "hk1:hv1;hk2:hv2;",
 			},
 		},
-		Spec: extensions.IngressSpec{
-			Rules: []extensions.IngressRule{
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: "www.http-router.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
 									Path: "/http-router",
-									Backend: extensions.IngressBackend{
-										ServiceName: "router-header-svc",
-										ServicePort: intstr.FromInt(80),
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "router-header-svc",
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
 									},
 								},
 							},
@@ -459,7 +471,7 @@ func TestHttpUpstreamHashBy(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	ingress := &extensions.Ingress{
+	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "upstreamhashby-ing",
 			Namespace: ns.Name,
@@ -467,18 +479,22 @@ func TestHttpUpstreamHashBy(t *testing.T) {
 				parser.GetAnnotationWithPrefix("upstream-hash-by"): "$request_uri",
 			},
 		},
-		Spec: extensions.IngressSpec{
-			Rules: []extensions.IngressRule{
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: "www.http-upstreamhashby.com",
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
 									Path: "/",
-									Backend: extensions.IngressBackend{
-										ServiceName: "upstreamhashby-svc",
-										ServicePort: intstr.FromInt(80),
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "upstreamhashby-svc",
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
 									},
 								},
 							},
@@ -555,15 +571,15 @@ func ensureService(service *corev1.Service, clientSet kubernetes.Interface, t *t
 
 }
 
-func ensureIngress(ingress *extensions.Ingress, clientSet kubernetes.Interface, t *testing.T) *extensions.Ingress {
+func ensureIngress(ingress *networkingv1.Ingress, clientSet kubernetes.Interface, t *testing.T) *networkingv1.Ingress {
 	t.Helper()
-	ing, err := clientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
+	ing, err := clientSet.NetworkingV1().Ingresses(ingress.Namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
 
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			t.Logf("Ingress %v not found, creating", ingress)
 
-			ing, err = clientSet.ExtensionsV1beta1().Ingresses(ingress.Namespace).Create(context.TODO(), ingress, metav1.CreateOptions{})
+			ing, err = clientSet.NetworkingV1().Ingresses(ingress.Namespace).Create(context.TODO(), ingress, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatalf("error creating ingress %+v: %v", ingress, err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e // indirect
 	google.golang.org/grpc v1.33.2
+	google.golang.org/protobuf v1.25.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/util/ingress-nginx/ingress/controller/store/ingress.go
+++ b/util/ingress-nginx/ingress/controller/store/ingress.go
@@ -17,7 +17,7 @@ limitations under the License.
 package store
 
 import (
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -27,7 +27,7 @@ type IngressLister struct {
 }
 
 // ByKey returns the Ingress matching key in the local Ingress store.
-func (il IngressLister) ByKey(key string) (*extensions.Ingress, error) {
+func (il IngressLister) ByKey(key string) (*networkingv1.Ingress, error) {
 	i, exists, err := il.GetByKey(key)
 	if err != nil {
 		return nil, err
@@ -35,5 +35,5 @@ func (il IngressLister) ByKey(key string) (*extensions.Ingress, error) {
 	if !exists {
 		return nil, NotExistsError(key)
 	}
-	return i.(*extensions.Ingress), nil
+	return i.(*networkingv1.Ingress), nil
 }

--- a/util/k8s/k8s.go
+++ b/util/k8s/k8s.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"encoding/json"
+	networkingv1 "k8s.io/api/networking/v1"
 	"net"
 	"os"
 
@@ -118,4 +119,9 @@ func CreatePatch(o, n, datastruct interface{}) ([]byte, error) {
 		return nil, err
 	}
 	return strategicpatch.CreateTwoWayMergePatch(oldData, newData, datastruct)
+}
+
+// IngressPathType -
+func IngressPathType(pathType networkingv1.PathType) *networkingv1.PathType {
+	return &pathType
 }

--- a/worker/appm/controller/start.go
+++ b/worker/appm/controller/start.go
@@ -162,7 +162,7 @@ func (s *startController) startOne(app v1.AppService) error {
 	if ingresses := app.GetIngress(true); ingresses != nil {
 		for _, ingress := range ingresses {
 			if len(ingress.ResourceVersion) == 0 {
-				_, err := s.manager.client.ExtensionsV1beta1().Ingresses(app.TenantID).Create(s.ctx, ingress, metav1.CreateOptions{})
+				_, err := s.manager.client.NetworkingV1().Ingresses(app.TenantID).Create(s.ctx, ingress, metav1.CreateOptions{})
 				if err != nil && !errors.IsAlreadyExists(err) {
 					return fmt.Errorf("create ingress failure:%s", err.Error())
 				}

--- a/worker/appm/conversion/gateway.go
+++ b/worker/appm/conversion/gateway.go
@@ -23,15 +23,15 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
+	
+	"github.com/goodrain/rainbond/util/k8s"
 	"github.com/goodrain/rainbond/db"
 	"github.com/goodrain/rainbond/db/model"
-	"github.com/goodrain/rainbond/event"
 	"github.com/goodrain/rainbond/gateway/annotations/parser"
 	v1 "github.com/goodrain/rainbond/worker/appm/types/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -89,7 +89,6 @@ type AppServiceBuild struct {
 	appService         *v1.AppService
 	replicationType    string
 	dbmanager          db.Manager
-	logger             event.Logger
 }
 
 //AppServiceBuilder returns a AppServiceBuild
@@ -144,7 +143,7 @@ func (a *AppServiceBuild) Build() (*v1.K8sResources, error) {
 	}
 
 	var services []*corev1.Service
-	var ingresses []*extensions.Ingress
+	var ingresses []*networkingv1.Ingress
 	var secrets []*corev1.Secret
 	if len(ports) > 0 {
 		for i := range ports {
@@ -194,8 +193,8 @@ func (a *AppServiceBuild) Build() (*v1.K8sResources, error) {
 
 // ApplyRules applies http rules and tcp rules
 func (a AppServiceBuild) ApplyRules(serviceID string, containerPort, pluginContainerPort int,
-	service *corev1.Service) ([]*extensions.Ingress, []*corev1.Secret, error) {
-	var ingresses []*extensions.Ingress
+	service *corev1.Service) ([]*networkingv1.Ingress, []*corev1.Secret, error) {
+	var ingresses []*networkingv1.Ingress
 	var secrets []*corev1.Secret
 	httpRules, err := a.dbmanager.HTTPRuleDao().GetHTTPRuleByServiceIDAndContainerPort(serviceID, containerPort)
 	if err != nil {
@@ -203,7 +202,7 @@ func (a AppServiceBuild) ApplyRules(serviceID string, containerPort, pluginConta
 	}
 	// create http ingresses
 	logrus.Debugf("find %d count http rule", len(httpRules))
-	if httpRules != nil && len(httpRules) > 0 {
+	if len(httpRules) > 0 {
 		for _, httpRule := range httpRules {
 			ing, sec, err := a.applyHTTPRule(httpRule, containerPort, pluginContainerPort, service)
 			if err != nil {
@@ -222,7 +221,7 @@ func (a AppServiceBuild) ApplyRules(serviceID string, containerPort, pluginConta
 	if err != nil {
 		logrus.Infof("Can't get TCPRule corresponding to ServiceID(%s): %v", serviceID, err)
 	}
-	if tcpRules != nil && len(tcpRules) > 0 {
+	if len(tcpRules) > 0 {
 		for _, tcpRule := range tcpRules {
 			ing, err := a.applyTCPRule(tcpRule, service, a.tenant.UUID)
 			if err != nil {
@@ -239,7 +238,7 @@ func (a AppServiceBuild) ApplyRules(serviceID string, containerPort, pluginConta
 
 // applyTCPRule applies stream rule into ingress
 func (a *AppServiceBuild) applyHTTPRule(rule *model.HTTPRule, containerPort, pluginContainerPort int,
-	service *corev1.Service) (ing *extensions.Ingress, sec *corev1.Secret, err error) {
+	service *corev1.Service) (ing *networkingv1.Ingress, sec *corev1.Secret, err error) {
 	// deal with empty path and domain
 	path := strings.Replace(rule.Path, " ", "", -1)
 	if path == "" {
@@ -251,24 +250,29 @@ func (a *AppServiceBuild) applyHTTPRule(rule *model.HTTPRule, containerPort, plu
 	}
 
 	// create ingress
-	ing = &extensions.Ingress{
+	ing = &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rule.UUID,
 			Namespace: a.tenant.UUID,
 			Labels:    a.appService.GetCommonLabels(),
 		},
-		Spec: extensions.IngressSpec{
-			Rules: []extensions.IngressRule{
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{
 				{
 					Host: domain,
-					IngressRuleValue: extensions.IngressRuleValue{
-						HTTP: &extensions.HTTPIngressRuleValue{
-							Paths: []extensions.HTTPIngressPath{
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
 								{
-									Path: path,
-									Backend: extensions.IngressBackend{
-										ServiceName: service.Name,
-										ServicePort: intstr.FromInt(pluginContainerPort),
+									Path:     path,
+									PathType: k8s.IngressPathType(networkingv1.PathTypeExact),
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: service.Name,
+											Port: networkingv1.ServiceBackendPort{
+												Number: int32(pluginContainerPort),
+											},
+										},
 									},
 								},
 							},
@@ -297,10 +301,10 @@ func (a *AppServiceBuild) applyHTTPRule(rule *model.HTTPRule, containerPort, plu
 	if rule.CertificateID != "" {
 		cert, err := a.dbmanager.CertificateDao().GetCertificateByID(rule.CertificateID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("Cant not get certificate by id(%s): %v", rule.CertificateID, err)
+			return nil, nil, fmt.Errorf("cant not get certificate by id(%s): %v", rule.CertificateID, err)
 		}
 		if cert == nil || strings.TrimSpace(cert.Certificate) == "" || strings.TrimSpace(cert.PrivateKey) == "" {
-			return nil, nil, fmt.Errorf("Rule id: %s; certificate not found", rule.UUID)
+			return nil, nil, fmt.Errorf("rule id: %s; certificate not found", rule.UUID)
 		}
 		// create secret
 		sec = &corev1.Secret{
@@ -315,7 +319,7 @@ func (a *AppServiceBuild) applyHTTPRule(rule *model.HTTPRule, containerPort, plu
 			},
 			Type: corev1.SecretTypeOpaque,
 		}
-		ing.Spec.TLS = []extensions.IngressTLS{
+		ing.Spec.TLS = []networkingv1.IngressTLS{
 			{
 				Hosts:      []string{domain},
 				SecretName: sec.Name,
@@ -356,7 +360,7 @@ func (a *AppServiceBuild) applyHTTPRule(rule *model.HTTPRule, containerPort, plu
 	if err != nil {
 		return nil, nil, err
 	}
-	if configs != nil && len(configs) > 0 {
+	if len(configs) > 0 {
 		for _, cfg := range configs {
 			annos[parser.GetAnnotationWithPrefix(cfg.Key)] = cfg.Value
 		}
@@ -367,18 +371,22 @@ func (a *AppServiceBuild) applyHTTPRule(rule *model.HTTPRule, containerPort, plu
 }
 
 // applyTCPRule applies stream rule into ingress
-func (a *AppServiceBuild) applyTCPRule(rule *model.TCPRule, service *corev1.Service, namespace string) (ing *extensions.Ingress, err error) {
+func (a *AppServiceBuild) applyTCPRule(rule *model.TCPRule, service *corev1.Service, namespace string) (ing *networkingv1.Ingress, err error) {
 	// create ingress
-	ing = &extensions.Ingress{
+	ing = &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rule.UUID,
 			Namespace: namespace,
 			Labels:    a.appService.GetCommonLabels(),
 		},
-		Spec: extensions.IngressSpec{
-			Backend: &extensions.IngressBackend{
-				ServiceName: service.Name,
-				ServicePort: intstr.FromInt(int(service.Spec.Ports[0].Port)),
+		Spec: networkingv1.IngressSpec{
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{
+					Name: service.Name,
+					Port: networkingv1.ServiceBackendPort{
+						Number: int32(service.Spec.Ports[0].Port),
+					},
+				},
 			},
 		},
 	}
@@ -526,8 +534,7 @@ func (a *AppServiceBuild) createOuterService(port *model.TenantServicesPort) *co
 	servicePort.Name = fmt.Sprintf("%s-%d",
 		strings.ToLower(string(servicePort.Protocol)), port.ContainerPort)
 	servicePort.Port = int32(port.ContainerPort)
-	var portType corev1.ServiceType
-	portType = corev1.ServiceTypeClusterIP
+	portType := corev1.ServiceTypeClusterIP
 	spec := corev1.ServiceSpec{
 		Ports: []corev1.ServicePort{servicePort},
 		Type:  portType,

--- a/worker/appm/store/lister.go
+++ b/worker/appm/store/lister.go
@@ -24,13 +24,13 @@ import (
 	appsv1 "k8s.io/client-go/listers/apps/v1"
 	autoscalingv2 "k8s.io/client-go/listers/autoscaling/v2beta2"
 	corev1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/listers/extensions/v1beta1"
+	networkingv1 "k8s.io/client-go/listers/networking/v1"
 	storagev1 "k8s.io/client-go/listers/storage/v1"
 )
 
 //Lister kube-api client cache
 type Lister struct {
-	Ingress                 v1beta1.IngressLister
+	Ingress                 networkingv1.IngressLister
 	Service                 corev1.ServiceLister
 	Secret                  corev1.SecretLister
 	StatefulSet             appsv1.StatefulSetLister

--- a/worker/appm/store/store.go
+++ b/worker/appm/store/store.go
@@ -49,7 +49,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	internalclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -222,7 +222,7 @@ func NewStore(
 	store.listers.ConfigMap = infFactory.Core().V1().ConfigMaps().Lister()
 
 	store.informers.Ingress = infFactory.Extensions().V1beta1().Ingresses().Informer()
-	store.listers.Ingress = infFactory.Extensions().V1beta1().Ingresses().Lister()
+	store.listers.Ingress = infFactory.Networking().V1().Ingresses().Lister()
 
 	store.informers.ReplicaSet = infFactory.Apps().V1().ReplicaSets().Informer()
 	store.listers.ReplicaSets = infFactory.Apps().V1().ReplicaSets().Lister()
@@ -609,7 +609,7 @@ func (a *appRuntimeStore) OnAdd(obj interface{}) {
 			}
 		}
 	}
-	if ingress, ok := obj.(*extensions.Ingress); ok {
+	if ingress, ok := obj.(*networkingv1.Ingress); ok {
 		serviceID := ingress.Labels["service_id"]
 		version := ingress.Labels["version"]
 		createrID := ingress.Labels["creater_id"]
@@ -722,8 +722,8 @@ func (a *appRuntimeStore) getAppService(serviceID, version, createrID string, cr
 }
 func (a *appRuntimeStore) OnUpdate(oldObj, newObj interface{}) {
 	// ingress update maybe change owner component
-	if ingress, ok := newObj.(*extensions.Ingress); ok {
-		oldIngress := oldObj.(*extensions.Ingress)
+	if ingress, ok := newObj.(*networkingv1.Ingress); ok {
+		oldIngress := oldObj.(*networkingv1.Ingress)
 		if oldIngress.Labels["service_id"] != ingress.Labels["service_id"] {
 			logrus.Infof("ingress %s change owner component", oldIngress.Name)
 			serviceID := oldIngress.Labels["service_id"]
@@ -832,7 +832,7 @@ func (a *appRuntimeStore) OnDeletes(objs ...interface{}) {
 				}
 			}
 		}
-		if ingress, ok := obj.(*extensions.Ingress); ok {
+		if ingress, ok := obj.(*networkingv1.Ingress); ok {
 			serviceID := ingress.Labels["service_id"]
 			version := ingress.Labels["version"]
 			createrID := ingress.Labels["creater_id"]


### PR DESCRIPTION
```
extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

Upgrade Ingress from extensions/v1beta1 to networking.k8s.io/v1. Refer to: #927