### PR TITLE
New Feature: file garbage collection

### DIFF
--- a/api/api/api_interface.go
+++ b/api/api/api_interface.go
@@ -147,6 +147,7 @@ type RulesInterface interface {
 //AppInterface app handle interface
 type AppInterface interface {
 	ExportApp(w http.ResponseWriter, r *http.Request)
+	DeleteExportedApp(w http.ResponseWriter, r *http.Request)
 	Download(w http.ResponseWriter, r *http.Request)
 	Upload(w http.ResponseWriter, r *http.Request)
 	NewUpload(w http.ResponseWriter, r *http.Request)

--- a/api/api_routers/version2/v2Routers.go
+++ b/api/api_routers/version2/v2Routers.go
@@ -361,6 +361,7 @@ func (v2 *V2) appRouter() chi.Router {
 	r := chi.NewRouter()
 	r.Post("/export", controller.GetManager().ExportApp)
 	r.Get("/export/{eventID}", controller.GetManager().ExportApp)
+	r.Delete("/export/{eventID}", controller.GetManager().DeleteExportedApp)
 
 	r.Get("/download/{format}/{fileName}", controller.GetManager().Download)
 	r.Post("/upload/{eventID}", controller.GetManager().NewUpload)

--- a/api/controller/app.go
+++ b/api/controller/app.go
@@ -72,6 +72,16 @@ func (a *AppStruct) ExportApp(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// DeleteExportedApp -
+func (a *AppStruct) DeleteExportedApp(w http.ResponseWriter, r *http.Request) {
+	eventID := chi.URLParam(r, "eventID")
+	err := handler.GetAppHandler().DeleteExportApp(r.Context(), eventID)
+	if err != nil {
+		httputil.ReturnBcodeError(r, w, err)
+		return
+	}
+}
+
 //Download -
 func (a *AppStruct) Download(w http.ResponseWriter, r *http.Request) {
 	format := strings.TrimSpace(chi.URLParam(r, "format"))

--- a/builder/exector/export_app.go
+++ b/builder/exector/export_app.go
@@ -70,6 +70,7 @@ func NewExportApp(in []byte, m *exectorManager) (TaskWorker, error) {
 
 //Run Run
 func (i *ExportApp) Run(timeout time.Duration) error {
+	defer os.RemoveAll(i.SourceDir)
 	// disable Md5 checksum
 	// if ok := i.isLatest(); ok {
 	// 	i.updateStatus("success")

--- a/builder/exector/groupapp_restore.go
+++ b/builder/exector/groupapp_restore.go
@@ -118,6 +118,9 @@ func (b *BackupAPPRestore) Run(timeout time.Duration) error {
 	if err := util.CheckAndCreateDir(cacheDir); err != nil {
 		return fmt.Errorf("create cache dir error %s", err.Error())
 	}
+	// delete the cache data
+	defer os.RemoveAll(cacheDir)
+
 	b.cacheDir = cacheDir
 	switch backup.BackupMode {
 	case "full-online":


### PR DESCRIPTION
1. Delete the cache data after restoring the app.
1. Delete the cache data after exporting the app.
1. Add a new API to delete the app exporting records.

Refer to: #976