### PR TITLE
New Feature: delete builder cache

### DIFF
--- a/builder/exector/export_app.go
+++ b/builder/exector/export_app.go
@@ -70,6 +70,7 @@ func NewExportApp(in []byte, m *exectorManager) (TaskWorker, error) {
 
 //Run Run
 func (i *ExportApp) Run(timeout time.Duration) error {
+	defer os.RemoveAll(i.SourceDir)
 	// disable Md5 checksum
 	// if ok := i.isLatest(); ok {
 	// 	i.updateStatus("success")

--- a/builder/exector/groupapp_restore.go
+++ b/builder/exector/groupapp_restore.go
@@ -118,6 +118,9 @@ func (b *BackupAPPRestore) Run(timeout time.Duration) error {
 	if err := util.CheckAndCreateDir(cacheDir); err != nil {
 		return fmt.Errorf("create cache dir error %s", err.Error())
 	}
+	// delete the cache data
+	defer os.RemoveAll(cacheDir)
+
 	b.cacheDir = cacheDir
 	switch backup.BackupMode {
 	case "full-online":


### PR DESCRIPTION
1. Delete the cache data after restoring the app.
1. Delete the cache data after exporting the app.