### PR TITLE
Pr/worker goroutine leak

### DIFF
--- a/worker/master/controller/thirdcomponent/discover/discover.go
+++ b/worker/master/controller/thirdcomponent/discover/discover.go
@@ -89,7 +89,7 @@ func (k *kubernetesDiscover) Discover(ctx context.Context, update chan *v1alpha1
 	if err != nil {
 		return nil, fmt.Errorf("load kubernetes service failure %s", err.Error())
 	}
-	re, err := k.client.CoreV1().Endpoints(namespace).Watch(ctx, metav1.ListOptions{LabelSelector: labels.FormatLabels(service.Spec.Selector)})
+	re, err := k.client.CoreV1().Endpoints(namespace).Watch(ctx, metav1.ListOptions{LabelSelector: labels.FormatLabels(service.Spec.Selector), Watch: true})
 	if err != nil {
 		return nil, fmt.Errorf("watch kubernetes endpoints failure %s", err.Error())
 	}
@@ -111,7 +111,6 @@ func (k *kubernetesDiscover) Discover(ctx context.Context, update chan *v1alpha1
 					logrus.Errorf("discover kubernetes endpoints %s change failure %s", component.Spec.EndpointSource.KubernetesService.Name, err.Error())
 				}
 			}()
-			return k.DiscoverOne(ctx)
 		}
 	}
 }

--- a/worker/master/controller/thirdcomponent/worker.go
+++ b/worker/master/controller/thirdcomponent/worker.go
@@ -31,14 +31,7 @@ func (w *Worker) Start() {
 	}()
 	w.stoped = false
 	logrus.Infof("discover endpoint list worker %s/%s  started", w.discover.GetComponent().Namespace, w.discover.GetComponent().Name)
-	for {
-		w.discover.Discover(w.ctx, w.updateChan)
-		select {
-		case <-w.ctx.Done():
-			return
-		default:
-		}
-	}
+	w.discover.Discover(w.ctx, w.updateChan)
 }
 
 // UpdateDiscover -


### PR DESCRIPTION
修复rbd-worker 由于第三方组件控制器引起的goroutine泄漏问题。
#1139 
