### PR TITLE
Fixed gateway failure after ingresss number increases

### DIFF
--- a/cmd/gateway/option/option.go
+++ b/cmd/gateway/option/option.go
@@ -108,7 +108,7 @@ func (g *GWServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&g.NginxUser, "nginx-user", "root", "n ginx user name")
 	fs.IntVar(&g.KeepaliveRequests, "keepalive-requests", 10000, "Number of requests a client can make over the keep-alive connection. ")
 	fs.IntVar(&g.KeepaliveTimeout, "keepalive-timeout", 30, "Timeout for keep-alive connections. Server will close connections after this time.")
-	fs.DurationVar(&g.ResyncPeriod, "resync-period", 10*time.Second, "the default resync period for any handlers added via AddEventHandler and how frequently the listener wants a full resync from the shared informer")
+	fs.DurationVar(&g.ResyncPeriod, "resync-period", 10*time.Minute, "the default resync period for any handlers added via AddEventHandler and how frequently the listener wants a full resync from the shared informer")
 	// etcd
 	fs.StringSliceVar(&g.EtcdEndpoint, "etcd-endpoints", []string{"http://127.0.0.1:2379"}, "etcd cluster endpoints.")
 	fs.IntVar(&g.EtcdTimeout, "etcd-timeout", 10, "etcd http timeout seconds")

--- a/gateway/store/store.go
+++ b/gateway/store/store.go
@@ -93,8 +93,6 @@ type Storer interface {
 
 	ListIngresses() interface{}
 
-	GetIngressAnnotations(key string) (*annotations.Ingress, error)
-
 	// Run initiates the synchronization of the controllers
 	Run(stopCh chan struct{})
 
@@ -197,25 +195,9 @@ func New(client kubernetes.Interface,
 
 	ingEventHandler := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			nwkIngress, ok := obj.(*networkingv1.Ingress)
-			if ok {
-				// updating annotations information for ingress
-				store.extractAnnotations(nwkIngress)
-				store.secretIngressMap.update(nwkIngress)
-				store.syncSecrets(nwkIngress)
-
-			} else {
-				betaIngress, ok := obj.(*betav1.Ingress)
-				if ok {
-					// updating annotations information for ingress
-					store.extractAnnotations(betaIngress)
-					store.secretIngressMap.update(betaIngress)
-					// synchronizes data from all Secrets referenced by the given Ingress with the local store and file system.
-					// takes an Ingress and updates all Secret objects it references in secretIngressMap.
-					store.syncSecrets(betaIngress)
-
-				}
-			}
+			store.extractAnnotations(obj)
+			store.secretIngressMap.update(obj)
+			store.syncSecrets(obj)
 
 			updateCh.In() <- Event{
 				Type: CreateEvent,
@@ -509,12 +491,12 @@ func (s *k8sStore) ListVirtualService() (l7vs []*v1.VirtualService, l4vs []*v1.V
 		if !s.ingressIsValid(item) {
 			continue
 		}
-		var ingName, ingNamespace, ingKey, ingServiceName string
+		var ingName, ingNamespace, ingServiceName string
 		isBetaIngress := false
+		var anns *annotations.Ingress
 		if ing, ok := item.(*networkingv1.Ingress); ok {
 			ingName = ing.Name
 			ingNamespace = ing.Namespace
-			ingKey = ik8s.MetaNamespaceKey(ing)
 			if ing.Spec.DefaultBackend == nil && ing.Spec.Rules != nil && len(ing.Spec.Rules) > 0 {
 				paths := ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths
 				if len(paths) == 0 {
@@ -525,6 +507,7 @@ func (s *k8sStore) ListVirtualService() (l7vs []*v1.VirtualService, l4vs []*v1.V
 			} else {
 				ingServiceName = ing.Spec.DefaultBackend.Service.Name
 			}
+			anns = s.annotations.Extract(&ing.ObjectMeta)
 		} else {
 			if ing, ok := item.(*betav1.Ingress); ok {
 				ingName = ing.Name
@@ -542,11 +525,7 @@ func (s *k8sStore) ListVirtualService() (l7vs []*v1.VirtualService, l4vs []*v1.V
 					ingServiceName = ing.Spec.Backend.ServiceName
 				}
 			}
-		}
-		anns, err := s.GetIngressAnnotations(ingKey)
-		if err != nil {
-			logrus.Errorf("Error getting Ingress annotations %q: %v", ingKey, err)
-			continue
+			anns = s.annotations.Extract(&ing.ObjectMeta)
 		}
 		if anns.L4.L4Enable && anns.L4.L4Port != 0 {
 			// region l4
@@ -850,19 +829,14 @@ func (s *k8sStore) ListVirtualService() (l7vs []*v1.VirtualService, l4vs []*v1.V
 			continue
 		}
 
-		var ingKey string
 		isBetaIngress := false
+		var anns *annotations.Ingress
 		if ing, ok := item.(*networkingv1.Ingress); ok {
-			ingKey = ik8s.MetaNamespaceKey(ing)
+			anns = s.annotations.Extract(&ing.ObjectMeta)
 		}
 		if ing, ok := item.(*betav1.Ingress); ok {
-			ingKey = ik8s.MetaNamespaceKey(ing)
 			isBetaIngress = true
-		}
-
-		anns, err := s.GetIngressAnnotations(ingKey)
-		if err != nil {
-			logrus.Errorf("Error getting Ingress annotations %q: %v", ingKey, err)
+			anns = s.annotations.Extract(&ing.ObjectMeta)
 		}
 
 		if !anns.Rewrite.ForceSSLRedirect {
@@ -1070,16 +1044,6 @@ func (s *k8sStore) GetServiceProtocol(key string, port int32) corev1.Protocol {
 	}
 
 	return corev1.ProtocolTCP
-}
-
-// GetIngressAnnotations returns the parsed annotations of an Ingress matching key.
-func (s k8sStore) GetIngressAnnotations(key string) (*annotations.Ingress, error) {
-	ia, err := s.listers.IngressAnnotation.ByKey(key)
-	if err != nil {
-		return &annotations.Ingress{}, err
-	}
-
-	return ia, nil
 }
 
 // Run initiates the synchronization of the informers.


### PR DESCRIPTION
当网关配置的数量上升后，新增，修改，删除网关时需要很久才能生效。详情见Issue:  #1122 
本次PR修复此bug。
出现此bug的原因：当gatewaycontroller的resyncPeriod缺省配置为10s，也就是每10s，informer的indexer中的key/value会同步到deltaFIFO队列，10s的时间间隔太短了，会不断的堆积到FIFO中，使得后续的list&watch配置入队延迟，便表现出了网关配置迟迟不生效的问题。

此外，还修复了gateway日志中出现 `Error getting Ingress annotations "{namespace}/{ingress}": no object matching key "{namespace}/{ingress}" in local store.`此类错误信息的情况。