### PR TITLE
Fixed gateway failure after ingresss number increases

### DIFF
--- a/cmd/gateway/option/option.go
+++ b/cmd/gateway/option/option.go
@@ -108,7 +108,7 @@ func (g *GWServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&g.NginxUser, "nginx-user", "root", "n ginx user name")
 	fs.IntVar(&g.KeepaliveRequests, "keepalive-requests", 10000, "Number of requests a client can make over the keep-alive connection. ")
 	fs.IntVar(&g.KeepaliveTimeout, "keepalive-timeout", 30, "Timeout for keep-alive connections. Server will close connections after this time.")
-	fs.DurationVar(&g.ResyncPeriod, "resync-period", 10*time.Second, "the default resync period for any handlers added via AddEventHandler and how frequently the listener wants a full resync from the shared informer")
+	fs.DurationVar(&g.ResyncPeriod, "resync-period", 10*time.Minute, "the default resync period for any handlers added via AddEventHandler and how frequently the listener wants a full resync from the shared informer")
 	// etcd
 	fs.StringSliceVar(&g.EtcdEndpoint, "etcd-endpoints", []string{"http://127.0.0.1:2379"}, "etcd cluster endpoints.")
 	fs.IntVar(&g.EtcdTimeout, "etcd-timeout", 10, "etcd http timeout seconds")


### PR DESCRIPTION
当网关配置的数量上升后，新增，修改，删除网关时需要很久才能生效。详情见Issue:  #1122 
本次PR修复此bug。
出现此bug的原因：当gatewaycontroller的resyncPeriod缺省配置为10s，也就是每10s，informer的indexer中的key/value会同步到deltaFIFO队列，10s的时间间隔太短了，会不断的堆积到FIFO中，使得后续的list&watch配置入队延迟，便表现出了网关配置迟迟不生效的问题。

此外，还修复了gateway日志中出现 `Error getting Ingress annotations "{namespace}/{ingress}": no object matching key "{namespace}/{ingress}" in local store.`此类错误信息的情况。