### PR TITLE
fix plugin command env not work bug

### DIFF
--- a/worker/appm/conversion/plugin.go
+++ b/worker/appm/conversion/plugin.go
@@ -107,7 +107,10 @@ func conversionServicePlugin(as *typesv1.AppService, dbmanager db.Manager) ([]v1
 				},
 			})
 		}
-		args, err := createPluginArgs(versionInfo.ContainerCMD, *envs)
+		args := make([]string, 0)
+		if len(versionInfo.ContainerCMD) > 0 {
+			args = []string{"/bin/sh", "-c", versionInfo.ContainerCMD}
+		}
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -374,16 +377,6 @@ func getPluginModel(pluginID, tenantID string, dbmanager db.Manager) (string, er
 	return plugin.PluginModel, nil
 }
 
-func createPluginArgs(cmd string, envs []v1.EnvVar) ([]string, error) {
-	if cmd == "" {
-		return nil, nil
-	}
-	configs := make(map[string]string, len(envs))
-	for _, env := range envs {
-		configs[env.Name] = env.Value
-	}
-	return strings.Split(util.ParseVariable(cmd, configs), " "), nil
-}
 func getXDSHostIPAndPort() (string, string, string) {
 	xdsHost := ""
 	xdsHostPort := "6101"

--- a/worker/appm/conversion/plugin.go
+++ b/worker/appm/conversion/plugin.go
@@ -107,13 +107,7 @@ func conversionServicePlugin(as *typesv1.AppService, dbmanager db.Manager) ([]v1
 				},
 			})
 		}
-		args := make([]string, 0)
-		if len(versionInfo.ContainerCMD) > 0 {
-			args = []string{"/bin/sh", "-c", versionInfo.ContainerCMD}
-		}
-		if err != nil {
-			return nil, nil, nil, err
-		}
+
 		pc := v1.Container{
 			Name:                   "plugin-" + pluginR.PluginID,
 			Image:                  versionInfo.BuildLocalImage,
@@ -121,9 +115,14 @@ func conversionServicePlugin(as *typesv1.AppService, dbmanager db.Manager) ([]v1
 			EnvFrom:                envFromSecrets,
 			Resources:              createPluginResources(pluginR.ContainerMemory, pluginR.ContainerCPU),
 			TerminationMessagePath: "",
-			Args:                   args,
 			VolumeMounts:           mainContainer.VolumeMounts,
 		}
+		
+		if len(versionInfo.ContainerCMD) > 0 {
+			pc.Command = []string{"/bin/sh", "-c"}
+			pc.Args = []string{versionInfo.ContainerCMD}
+		}
+
 		pluginModel, err := getPluginModel(pluginR.PluginID, as.TenantID, dbmanager)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("get plugin model info failure %s", err.Error())


### PR DESCRIPTION
修复bug #1185 
容器的命令行直接使用 "/bin/sh -c {command}"的方式运行，可以将所有方式设置的环境变量生效。