### PR TITLE
fix: backup failure and recovery data loss

### DIFF
--- a/builder/exector/groupapp_backup.go
+++ b/builder/exector/groupapp_backup.go
@@ -333,8 +333,14 @@ func (b *BackupAPPNew) checkVersionExist(version *dbmodel.VersionInfo) (bool, er
 		}
 		_, err = reg.Manifest(imageInfo.Name, imageInfo.Tag)
 		if err != nil {
-			logrus.Errorf("get image %s manifest info failure [%v], it could be not exist", version.DeliveredPath, err)
-			return false, err
+			logrus.Errorf("get image [%s] manifest info failure [%v], it could be not exist", version.DeliveredPath, err)
+			// Compatible with MediaTypeManifest
+			_, err := reg.ManifestV2(imageInfo.Name, imageInfo.Tag)
+			if err != nil {
+				logrus.Errorf("get image [%s] manifestV2 info failure [%v], it could be not exist", version.DeliveredPath, err)
+				return false, err
+			}
+			return true, nil
 		}
 		return true, nil
 	}

--- a/builder/exector/groupapp_restore_test.go
+++ b/builder/exector/groupapp_restore_test.go
@@ -19,6 +19,7 @@
 package exector
 
 import (
+	"github.com/goodrain/rainbond/builder"
 	"testing"
 
 	"github.com/pquerna/ffjson/ffjson"
@@ -79,5 +80,41 @@ func TestUnzipAllDataFile(t *testing.T) {
 	allTmpDir := "/tmp/4f25c53e864744ec95d037528acaa708"
 	if err := util.Unzip(allDataFilePath, allTmpDir); err != nil {
 		logrus.Errorf("unzip all data file failure %s", err.Error())
+	}
+}
+
+func TestGetImageName(t *testing.T) {
+	testData := []struct {
+		builderRegistryDomain string
+		imageName             string
+		result                string
+	}{
+		{
+			imageName:             "goodrain.me/nginx:latest",
+			builderRegistryDomain: "goodrain.me",
+			result:                "goodrain.me/nginx:latest",
+		},
+		{
+			imageName:             "registry.cn-hangzhou.aliyuncs.com/nginx:latest",
+			builderRegistryDomain: "goodrain.me",
+			result:                "goodrain.me/nginx:latest",
+		},
+		{
+			imageName:             "goodrain.me/nginx:latest",
+			builderRegistryDomain: "registry.cn-hangzhou.aliyuncs.com/local",
+			result:                "registry.cn-hangzhou.aliyuncs.com/local/nginx:latest",
+		},
+		{
+			imageName:             "goodrain.me/goodrain/nginx:latest",
+			builderRegistryDomain: "registry.cn-hangzhou.aliyuncs.com/local",
+			result:                "registry.cn-hangzhou.aliyuncs.com/local/nginx:latest",
+		},
+	}
+	for _, ts := range testData {
+		builder.REGISTRYDOMAIN = ts.builderRegistryDomain
+		newImage := getNewImageName(ts.imageName)
+		if newImage != ts.result {
+			t.Fatalf("Except [%s], But got [%s]", ts.result, newImage)
+		}
 	}
 }

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -160,6 +160,14 @@ func (i Image) GetSimpleName() string {
 	return i.GetRepostory()
 }
 
+//GetNamespace get namespace
+func (i Image) GetNamespace() string {
+	if strings.Contains(i.GetRepostory(), "/") {
+		return strings.Split(i.GetRepostory(), "/")[0]
+	}
+	return ""
+}
+
 //Parser 解析器
 type Parser interface {
 	Parse() ParseErrorList


### PR DESCRIPTION
相关Issues：https://github.com/goodrain/rainbond/issues/1203

问题：
1. 备份失败是由于 MediaTypeManifest 校验有问题导致的，因此需要支持兼容 V2 版本的 MediaTypeManifest

2. 恢复失败是由于对接外部镜像仓库，如 registry.cn-hangzhou.aliyuncs.com/local ，此时处理镜像时，会将原镜像 registry.cn-hangzhou.aliyuncs.com/local/nginx:latest 变为 registry.cn-hangzhou.aliyuncs.com/local/local/nginx:latest，导致找不到镜像，从而无法恢复。对接内部镜像仓库 goodrain.me 暂无该问题。

3. 恢复成功以后组件数据丢失，是因为 5.5 版本以后，支持修改组件的 POD_NAME ，导致存储路径发生改变。因此在 region 这一层，暂时将恢复的组件数据路径改为 /grdata/tenant/{tenant_id}/services/{service_id}/{storage_path}/{service_alias}，最终再由控制台调用 region 端接口，修改存储路径。参考 https://github.com/goodrain/rainbond-console/pull/1098