### PR TITLE
feat(api): add health check endpoint for rbd-api

### DIFF
--- a/cmd/api/option/option.go
+++ b/cmd/api/option/option.go
@@ -25,10 +25,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
-//Config config
+// Config config
 type Config struct {
 	DBType                 string
 	APIAddr                string
+	APIHealthzAddr         string
 	APIAddrSSL             string
 	DBConnectionInfo       string
 	EventLogServers        []string
@@ -65,24 +66,25 @@ type Config struct {
 	GrctlImage             string
 }
 
-//APIServer  apiserver server
+// APIServer  apiserver server
 type APIServer struct {
 	Config
 	LogLevel       string
 	StartRegionAPI bool
 }
 
-//NewAPIServer new server
+// NewAPIServer new server
 func NewAPIServer() *APIServer {
 	return &APIServer{}
 }
 
-//AddFlags config
+// AddFlags config
 func (a *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.LogLevel, "log-level", "info", "the api log level")
 	fs.StringVar(&a.DBType, "db-type", "mysql", "db type mysql or etcd")
 	fs.StringVar(&a.DBConnectionInfo, "mysql", "admin:admin@tcp(127.0.0.1:3306)/region", "mysql db connection info")
 	fs.StringVar(&a.APIAddr, "api-addr", "127.0.0.1:8888", "the api server listen address")
+	fs.StringVar(&a.APIHealthzAddr, "api-healthz-addr", "0.0.0.0:8889", "the api server health check listen address")
 	fs.StringVar(&a.APIAddrSSL, "api-addr-ssl", "0.0.0.0:8443", "the api server listen address")
 	fs.StringVar(&a.WebsocketAddr, "ws-addr", "0.0.0.0:6060", "the websocket server listen address")
 	fs.BoolVar(&a.APISSL, "api-ssl-enable", false, "whether to enable websocket  SSL")
@@ -119,7 +121,7 @@ func (a *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&a.GrctlImage, "shell-image", "registry.cn-hangzhou.aliyuncs.com/goodrain/rbd-shell:v5.10.0-release", "use shell image")
 }
 
-//SetLog 设置log
+// SetLog 设置log
 func (a *APIServer) SetLog() {
 	level, err := logrus.ParseLevel(a.LogLevel)
 	if err != nil {

--- a/hack/contrib/docker/shell/Dockerfile
+++ b/hack/contrib/docker/shell/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.17
+ARG RELEASE_DESC
+COPY . /usr/local/bin/
+RUN apk update && apk add wget jq bash && \
+    wget https://goodrain-delivery.oss-cn-hangzhou.aliyuncs.com/kubectl-linux-$(arch)-1.23.10 -O /usr/bin/kubectl && \
+    chmod +x /usr/local/bin/grctl && \
+    chmod +x /usr/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl-rbd
+ENV RELEASE_DESC=${RELEASE_DESC}
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/hack/contrib/docker/shell/docker-entrypoint.sh
+++ b/hack/contrib/docker/shell/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ "$1" = "bash" ];then
+    exec /bin/bash
+elif [ "${1}" = 'version' ];then
+    echo "kubectl-$(kubectl version --client -o json | jq .clientVersion.gitVersion | sed s/\"//g)-grctl-\"$(grctl version)\""
+else
+    exec /docker-entrypoint.sh "$@"
+fi 

--- a/hack/contrib/docker/shell/kubectl-rbd
+++ b/hack/contrib/docker/shell/kubectl-rbd
@@ -1,0 +1,2 @@
+#!/bin/sh
+grctl $@


### PR DESCRIPTION
Add a separate health check service endpoint for the rbd-api service. So that we can configure the health check on cloud provider loadbalancer without tls authentication.