### PR TITLE
fix: rbd-eventlog unhealthy

### DIFF
--- a/eventlog/store/manager.go
+++ b/eventlog/store/manager.go
@@ -46,7 +46,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//Manager 存储管理器
+// Manager 存储管理器
 type Manager interface {
 	ReceiveMessageChan() chan []byte
 	SubMessageChan() chan [][]byte
@@ -65,7 +65,7 @@ type Manager interface {
 	HealthCheck() map[string]string
 }
 
-//NewManager 存储管理器
+// NewManager 存储管理器
 func NewManager(conf conf.EventStoreConf, log *logrus.Entry) (Manager, error) {
 	conf.DB.Type = "eventfile"
 	dbPlugin, err := db.NewManager(conf.DB, log)
@@ -138,10 +138,10 @@ func (s *storeManager) HealthCheck() map[string]string {
 	return map[string]string{"status": "health", "info": "eventlog service health"}
 }
 
-//Scrape prometheue monitor metrics
-//step1: docker log monitor
-//step2: event message monitor
-//step3: monitor message monitor
+// Scrape prometheue monitor metrics
+// step1: docker log monitor
+// step2: event message monitor
+// step3: monitor message monitor
 var healthStatus float64
 
 func (s *storeManager) Scrape(ch chan<- prometheus.Metric, namespace, exporter, from string) error {
@@ -266,7 +266,7 @@ func (s *storeManager) Run() error {
 	return nil
 }
 
-//cleanLog
+// cleanLog
 // clean service log that before 7 days in every 24h
 // clean event log that before 30 days message in every 24h
 func (s *storeManager) cleanLog() {
@@ -345,7 +345,7 @@ func (s *storeManager) parsingMessage(msg []byte, messageType string) (*db.Event
 	return nil, errors.New("unable to process configuration of message format type")
 }
 
-//handleNewMonitorMessage 处理新监控数据
+// handleNewMonitorMessage 处理新监控数据
 func (s *storeManager) handleNewMonitorMessage() {
 loop:
 	for {
@@ -448,6 +448,17 @@ type containerLog struct {
 	Time        json.RawMessage `json:"time"`
 }
 
+const (
+	// RBDSERVICEIDAPI rbd service id api
+	RBDSERVICEIDAPI = "rbd-api"
+	// RBDSERVICEIDWORKER rbd service id worker
+	RBDSERVICEIDWORKER = "rbd-worker"
+	// RBDSERVICEIDGATEWAY rbd service id gateway
+	RBDSERVICEIDGATEWAY = "rbd-gateway"
+	// RBDSERVICEIDCHAOS rbd service id chaos
+	RBDSERVICEIDCHAOS = "rbd-chaos"
+)
+
 func (s *storeManager) handleDockerLog() {
 	s.log.Debug("event message store manager start handle docker container log message")
 loop:
@@ -469,11 +480,17 @@ loop:
 			containerID := m[0:12]        //0-12
 			serviceID := string(m[13:45]) //13-45
 			// rbd logs
-			if strings.Contains(serviceID, "rbd-") {
-				nameSlice := strings.Split(serviceID, "time")
-				serviceID = nameSlice[0]
+			switch {
+			case strings.Contains(serviceID, RBDSERVICEIDAPI):
+				serviceID = RBDSERVICEIDAPI
+			case strings.Contains(serviceID, RBDSERVICEIDWORKER):
+				serviceID = RBDSERVICEIDWORKER
+			case strings.Contains(serviceID, RBDSERVICEIDGATEWAY):
+				serviceID = RBDSERVICEIDGATEWAY
+			case strings.Contains(serviceID, RBDSERVICEIDCHAOS):
+				serviceID = RBDSERVICEIDCHAOS
 			}
-			log := m[45:]
+			log := m[13+len(serviceID):]
 			logrus.Debugf("containerID [%s] serviceID [%s] log [%s]", containerID, serviceID, string(log))
 			buffer := bytes.NewBuffer(containerID)
 			buffer.WriteString(":")
@@ -526,7 +543,7 @@ func (s *storeManager) Error() chan error {
 	return s.errChan
 }
 
-//GetDockerLogs get history docker log
+// GetDockerLogs get history docker log
 func (s *storeManager) GetDockerLogs(serviceID string, length int) []string {
 	return s.dockerLogStore.GetHistoryMessage(serviceID, length)
 }


### PR DESCRIPTION
问题原因：
1. 在 eventlog 处理日志时，使用 serviceID 作为唯一 key，serviceID 是一个 32 位的 uuid 字符串，而平台内部组件（api、worker）等，我们将其 ServiceID 命名为 rbd-api 等。

2. serviceID 与每一条日志消息绑定，所以处理的消息类似于 `rbd-apitime="2023-01-16T23:35:17+08:00" level=debug msg="update event handle core success,handle core count:1, event server count:1"`

3. 由于平台内部组件（api、worker）的 ServiceID 与正常业务组件的长度不同，所以这里原逻辑是通过 `time` 字段切分的，当设置外部健康检测时，因为请求的端口 8443 需要证书，所以会有这类不属于我们组件自身的日志 `rbd-api2023/01/16 23:39:37 http: TLS handshake error from 10.10.10.24:50928: EOF`，这类消息中没有 `time` 字段，所以导致使用这条消息的前 32 位 `rbd-api2023/01/16 23:39:37` 作为 ServiceID。

4. 这样的后果是每一条容器日志都被认为是一个单独的组件日志，并分别单独落盘和垃圾回收（每次落盘和垃圾回收都会加锁），最终导致内部消息通道阻塞，无法接收新的日志消息。

解决方案：
1. 对于平台内部组件，根据其名字将 serviceID 正确切分出来，保证一个组件所对应的 ServiceID 不会因为日志内容而改变。