### PR TITLE
fix: etcd insecure

### DIFF
--- a/pkg/component/etcd/etcdComponent.go
+++ b/pkg/component/etcd/etcdComponent.go
@@ -85,8 +85,8 @@ func (e *Component) Start(ctx context.Context, cfg *configs.Config) error {
 			return err
 		}
 		config.TLS = tlsConfig
+	} else {
 		config.DialOptions = []grpc.DialOption{grpc.WithInsecure()}
-
 	}
 	gogo.Go(func(ctx context.Context) error {
 		var err error


### PR DESCRIPTION
修复在设置了etcd时，还使用了不安全链接，导致etcd无法连接