### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/node/api/controller/cluster_controller.go
+++ b/node/api/controller/cluster_controller.go
@@ -319,7 +319,7 @@ func ClusterInfo(w http.ResponseWriter, r *http.Request) {
 	var healthCapMem int64
 	var unhealthCapCPU int64
 	var unhealthCapMem int64
-	usedNodeList := make([]*v1.Node, len(nodes))
+	usedNodeList := make([]*v1.Node, 0, len(nodes))
 	for i, v := range nodes {
 		nodeHealth := false
 		for _, con := range v.Status.Conditions {


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242650479/job/25425738007

```
====================================================================================================
append to slice `usedNodeList` with non-zero initialized length at https://github.com/goodrain/rainbond/blob/main/node/api/controller/cluster_controller.go#L33[9](https://github.com/alingse/go-linter-runner/actions/runs/9242650479/job/25425738007#step:4:10):19
====================================================================================================
```