### PR TITLE
fix: 修复 chaos 服务重启期间任务丢失问题 

### DIFF
--- a/builder/exector/exector.go
+++ b/builder/exector/exector.go
@@ -267,6 +267,11 @@ func (e *exectorManager) RunTask(task *pb.TaskMessage) {
 		go e.runTask(e.garbageCollection, task, false)
 	case "build_from_kubeblocks":
 		go e.runTask(e.buildFromKubeBlocks, task, false)
+	case "warmup":
+		// 预热任务，用于确保消费循环已经启动，避免 lost wakeup 问题
+		// 直接忽略，从任务队列中移除即可
+		logrus.Info("[RunTask] Received warmup task, consumer loop is active")
+		<-e.tasks // 从队列中移除
 	default:
 		logrus.Warnf("[RunTask] Unknown task type: %s, using default handler", task.TaskType)
 		go e.runTaskWithErr(e.exec, task, false)


### PR DESCRIPTION
问题：
- chaos 服务重启后立即接收任务会导致任务丢失
- 内存队列存在 lost wakeup 竞态条件，导致第一次任务偶尔收不到

解决方案：
1. 添加服务就绪状态标记和健康检查端点，返回 503 状态码提示服务未就绪
2. 启动时增加预热机制，发送 warmup 任务激活消费循环，避免 lost wakeup
3. API 层在发送构建任务前检查 chaos 健康状态，支持最多 5 次重试（共 10 秒）
4. 健康检查通过实际发送接收测试消息验证 MQ 循环就绪，而非仅检查标志位

影响范围：
- builder/discover: 添加就绪标记、预热任务发送
- builder/exector: 处理 warmup 任务类型
- builder/api/controller: 改进健康检查实现
- api/handler: ServiceBuild 前置健康检查和重试逻辑