### PR TITLE
feat: optimize event log storage and retention

### DIFF
--- a/pkg/component/storage/local_storage.go
+++ b/pkg/component/storage/local_storage.go
@@ -324,3 +324,12 @@ func (l *LocalStorage) CleanupChunks(sessionID string) error {
 	logrus.Debugf("Cleaned up chunks for session: %s", sessionID)
 	return nil
 }
+
+// ReadFile reads a file directly from local storage and returns a reader
+func (l *LocalStorage) ReadFile(filePath string) (ReadCloser, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	return file, nil
+}

--- a/pkg/component/storage/storage.go
+++ b/pkg/component/storage/storage.go
@@ -73,6 +73,8 @@ type InterfaceStorage interface {
 	UploadFileToFile(src string, dst string, logger event.Logger) error
 	DownloadDirToDir(srcDir, dstDir string) error
 	DownloadFileToDir(srcFile, dstDir string) error
+	// ReadFile reads a file directly from storage and returns a reader
+	ReadFile(filePath string) (ReadCloser, error)
 
 	// 分片上传相关方法
 	SaveChunk(sessionID string, chunkIndex int, reader multipart.File) (string, error)
@@ -80,6 +82,11 @@ type InterfaceStorage interface {
 	ChunkExists(sessionID string, chunkIndex int) bool
 	CleanupChunks(sessionID string) error
 	GetChunkDir(sessionID string) string
+}
+
+type ReadCloser interface {
+	Read(p []byte) (n int, err error)
+	Close() error
 }
 
 type SrcFile interface {


### PR DESCRIPTION
1. Add direct stream reading from storage
   - Add ReadFile interface to storage layer
   - Implement ReadFile in S3Storage and LocalStorage
   - Enable direct streaming from MinIO without local download

2. Refactor event log retrieval
   - Modify GetMessages to read directly from storage
   - Remove downloadWithRetry method (no longer needed)
   - Add fallback to local file for backward compatibility
   - Reduce disk usage and improve performance

3. Configure event log permanent retention
   - Remove event log auto-cleanup rule from MinIO lifecycle
   - Keep logs/eventlog/ files permanently
   - Other cleanup policies remain unchanged

Changes:
- api/eventlog/db/eventFilePlugin.go: refactor to use direct streaming
- pkg/component/storage/storage.go: add ReadFile interface
- pkg/component/storage/s3_storage.go: implement ReadFile and remove log cleanup rule
- pkg/component/storage/local_storage.go: implement ReadFile