### PR TITLE
fix: change misleading timeout log from WARN to DEBUG in rbd-chaos

### DIFF
--- a/builder/discover/discover.go
+++ b/builder/discover/discover.go
@@ -139,11 +139,11 @@ func (t *TaskManager) Do(errChan chan error) {
 			cancel()
 			if err != nil {
 				if grpc1.ErrorDesc(err) == context.DeadlineExceeded.Error() {
-					logrus.Warn(err.Error())
+					logrus.Debug("waiting for build task...")
 					continue
 				}
 				if grpc1.ErrorDesc(err) == "context timeout" {
-					logrus.Warn(err.Error())
+					logrus.Debug("waiting for build task...")
 					continue
 				}
 				logrus.Errorf("message dequeue failure %s, will retry", err.Error())


### PR DESCRIPTION
  When the MQ queue is empty, the Dequeue operation times out after 5 seconds
  which is expected behavior. Changed to DEBUG level with message
  'waiting for build task...' to better reflect normal idle polling behavior.