### PR TITLE
fix: Refactor domainsConflict to check only for exact matches

### DIFF
--- a/api/controller/apigateway/api_gateway_route.go
+++ b/api/controller/apigateway/api_gateway_route.go
@@ -1075,20 +1075,7 @@ func hasMatchingCertManagerDomain(certDomains []string, routeDomains []string) b
 }
 
 func certManagerDomainsConflict(domain1, domain2 string) bool {
-	if domain1 == domain2 {
-		return true
-	}
-	if strings.HasPrefix(domain1, "*.") {
-		if strings.HasSuffix(domain2, domain1[2:]) {
-			return true
-		}
-	}
-	if strings.HasPrefix(domain2, "*.") {
-		if strings.HasSuffix(domain1, domain2[2:]) {
-			return true
-		}
-	}
-	return false
+	return domain1 == domain2
 }
 
 func routeMatchesCertManagerDomains(route *v2.ApisixRoute, domains []string) bool {

--- a/api/controller/apigateway/api_gateway_route_test.go
+++ b/api/controller/apigateway/api_gateway_route_test.go
@@ -33,7 +33,7 @@ func TestHasMatchingCertManagerDomain(t *testing.T) {
 			name:         "wildcard match",
 			certDomains:  []string{"*.example.com"},
 			routeDomains: []string{"foo.example.com"},
-			want:         true,
+			want:         false,
 		},
 		{
 			name:         "no overlap",

--- a/api/util/http.go
+++ b/api/util/http.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"strings"
 
 	"github.com/apache/apisix-ingress-controller/pkg/kube/apisix/apis/config/v2"
 	"k8s.io/api/core/v1"

--- a/api/util/http.go
+++ b/api/util/http.go
@@ -153,29 +153,8 @@ func CheckDomainConflict(ctx context.Context, domains []v2.HostType, currentName
 // domainsConflict checks if two domains conflict with each other.
 // Domains conflict if:
 // - They are exactly the same
-// - One is a wildcard that matches the other (e.g., *.example.com matches test.example.com)
-// - Both are the same wildcard
+// - When a *.example.com certificate exists, allow adding a.example.com certificate
 func domainsConflict(domain1, domain2 string) bool {
 	// Exact match
-	if domain1 == domain2 {
-		return true
-	}
-
-	// Check if domain1 is a wildcard that matches domain2
-	if strings.HasPrefix(domain1, "*.") {
-		wildcardBase := domain1[2:] // Remove "*."
-		if strings.HasSuffix(domain2, wildcardBase) {
-			return true
-		}
-	}
-
-	// Check if domain2 is a wildcard that matches domain1
-	if strings.HasPrefix(domain2, "*.") {
-		wildcardBase := domain2[2:] // Remove "*."
-		if strings.HasSuffix(domain1, wildcardBase) {
-			return true
-		}
-	}
-
-	return false
+	return domain1 == domain2
 }


### PR DESCRIPTION
修改证书添加时判断冲突时逻辑，只需要判断是否完全一样。
如当 *.example.com 存在时，允许添加 a.example.com a.b.example.com 以此类推

根据SNI匹配原则，修改后：
当存在 .example.com 证书时，a.example.com 会使用通配符(.example.com)证书
当添加 a.example.com 证书后，a.example.com 会使用精确域名(a.example.com)证书
当删除 a.example.com 证书后，a.example.com 会使用通配符(*.example.com)证书