### PR TITLE
ci: build multi-arch manifest for rainbond-ui and fix dev-build ui image default

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -45,9 +45,12 @@ on:
         required: false
         default: ''
       ui-image-tag:
-        description: '不重打前端时，console 复用的现成 UI 镜像 tag（需已存在）'
+        # dev 构建为 amd64 单架构，且历史多架构 release 的 UI 镜像只有 -amd64/-arm64
+        # 后缀（无合并 manifest），故默认用 -amd64 后缀的现存 tag。
+        # 注：release-v6.yml 已补上 UI 多架构 manifest，后续新版本可改用无后缀 tag。
+        description: '不重打前端时 console 复用的现成 UI 镜像 tag（需已存在；dev 为 amd64，默认用 -amd64 后缀）'
         required: false
-        default: 'v6.8.1-release'
+        default: 'v6.8.1-release-amd64'
       run-unit-test:
         description: '是否跑 Go 单测（region/all 时生效）'
         required: false

--- a/.github/workflows/release-v6.yml
+++ b/.github/workflows/release-v6.yml
@@ -329,3 +329,11 @@ jobs:
               registry.cn-hangzhou.aliyuncs.com/goodrain/rainbond:${VERSION}-amd64 \
               registry.cn-hangzhou.aliyuncs.com/goodrain/rainbond:${VERSION}-arm64
           fi
+
+          # Rainbond UI（仅推 Docker Hub，故只合并该处的多架构 manifest）
+          if [[ "$BUILD_WHO" == "all" || "$BUILD_WHO" == "console" ]]; then
+            echo "Creating manifest for rainbond-ui..."
+            docker buildx imagetools create -t rainbond/rainbond-ui:${VERSION} \
+              rainbond/rainbond-ui:${VERSION}-amd64 \
+              rainbond/rainbond-ui:${VERSION}-arm64
+          fi


### PR DESCRIPTION
The multi-arch-manifest job listed rainbond-ui in needs but never merged its per-arch images into a combined tag, so multi-arch releases only produced rainbond-ui:<ver>-amd64/-arm64 with no rainbond-ui:<ver>. Add the UI manifest step, and default dev-build ui-image-tag to the existing -amd64 tag.