### PR TITLE
fix(test-manifest): register missing capabilities to unblock CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,44 @@ db.GetManager().TenantServiceDao().GetServiceByID(serviceID)
 ```bash
 go build ./...          # Compile all packages
 go vet ./...            # Static analysis
-make check              # CI lint check (golint on changed files)
+make check              # CI lint check (golint on changed files) + test manifest validation
+make test-manifest-check # Validate test-manifest.json against capability_id markers
 make build              # Build binaries via localbuild.sh
 ```
+
+## Test Manifest (CI-enforced)
+
+`test-manifest.json` is a registry of behavior-guarding tests. Any test annotated
+with a `capability_id` comment is a "managed" test and MUST have a matching entry
+in the manifest, otherwise CI fails.
+
+- Marker: `// capability_id: rainbond.<area>.<behavior>` (Go) or
+  `# capability_id: ...` (Python), placed directly above the test function.
+- Enforced by `scripts/validate_test_manifest.py`, invoked from `make check` and
+  `make test-manifest-check`. Runs in CI as the **Check test manifest** step in
+  `.github/workflows/pr-ci-build.yml` and `release-v6.yml`.
+- `test-manifest.md` is the human-readable table — **auto-generated, never edit by hand**.
+
+### Registering a managed test
+
+Do NOT hand-edit `test-manifest.json`. Use the manager — it inserts in sorted order
+and regenerates `test-manifest.md`:
+
+```bash
+python3 scripts/manage_test_manifest.py add rainbond.<area>.<behavior> \
+  --title "Short English summary" \
+  --interface-type workflow \
+  --interface "builder/sources.buildKitTomlContent" \
+  --code-path builder/sources/image.go \
+  --test builder/sources/buildkit_toml_test.go::TestBuildKitTomlContent \
+  --test-type regression
+```
+
+- `interface_type`: one of `service_method | view_endpoint | handler_method |
+  dao_method | package_function | workflow | other` (internal funcs/methods use `workflow`).
+- `test_type`: one of `unit | regression | characterization | integration`.
+- Repeat `--code-path` / `--test` for multiple values; `--status` defaults to `active`.
+- Other subcommands: `list`, `show <id>`, `render` (rebuild the `.md`), `prune <id>`.
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,9 +113,44 @@ db.GetManager().TenantServiceDao().GetServiceByID(serviceID)
 ```bash
 go build ./...          # Compile all packages
 go vet ./...            # Static analysis
-make check              # CI lint check (golint on changed files)
+make check              # CI lint check (golint on changed files) + test manifest validation
+make test-manifest-check # Validate test-manifest.json against capability_id markers
 make build              # Build binaries via localbuild.sh
 ```
+
+## Test Manifest (CI-enforced)
+
+`test-manifest.json` is a registry of behavior-guarding tests. Any test annotated
+with a `capability_id` comment is a "managed" test and MUST have a matching entry
+in the manifest, otherwise CI fails.
+
+- Marker: `// capability_id: rainbond.<area>.<behavior>` (Go) or
+  `# capability_id: ...` (Python), placed directly above the test function.
+- Enforced by `scripts/validate_test_manifest.py`, invoked from `make check` and
+  `make test-manifest-check`. Runs in CI as the **Check test manifest** step in
+  `.github/workflows/pr-ci-build.yml` and `release-v6.yml`.
+- `test-manifest.md` is the human-readable table — **auto-generated, never edit by hand**.
+
+### Registering a managed test
+
+Do NOT hand-edit `test-manifest.json`. Use the manager — it inserts in sorted order
+and regenerates `test-manifest.md`:
+
+```bash
+python3 scripts/manage_test_manifest.py add rainbond.<area>.<behavior> \
+  --title "Short English summary" \
+  --interface-type workflow \
+  --interface "builder/sources.buildKitTomlContent" \
+  --code-path builder/sources/image.go \
+  --test builder/sources/buildkit_toml_test.go::TestBuildKitTomlContent \
+  --test-type regression
+```
+
+- `interface_type`: one of `service_method | view_endpoint | handler_method |
+  dao_method | package_function | workflow | other` (internal funcs/methods use `workflow`).
+- `test_type`: one of `unit | regression | characterization | integration`.
+- Repeat `--code-path` / `--test` for multiple values; `--status` defaults to `active`.
+- Other subcommands: `list`, `show <id>`, `render` (rebuild the `.md`), `prune <id>`.
 
 ## Coding Conventions
 

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -1415,6 +1415,28 @@
       "status": "active"
     },
     {
+      "id": "rainbond.dockerfile-build.registry-mirror-toml",
+      "title": "Render BuildKit TOML with optional registry mirrors",
+      "title_zh": "Render BuildKit TOML with optional registry mirrors",
+      "interface_type": "workflow",
+      "interface": "builder/sources.buildKitTomlContent",
+      "code_paths": [
+        "builder/sources/image.go"
+      ],
+      "tests": [
+        {
+          "path": "builder/sources/buildkit_toml_test.go",
+          "selector": "TestBuildKitTomlContent"
+        },
+        {
+          "path": "builder/sources/buildkit_toml_test.go",
+          "selector": "TestBuildKitTomlContentLegacyEquivalence"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "rainbond.dockerfile.line-info",
       "title": "Track Dockerfile AST line information",
       "title_zh": "\u8ddf\u8e2a Dockerfile AST \u7684\u884c\u53f7\u4fe1\u606f",
@@ -5083,6 +5105,42 @@
         {
           "path": "pkg/apis/rainbond/v1alpha1/third_component_unit_test.go",
           "selector": "TestThirdComponentSpecIsStaticEndpoints"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.upgrade-configmap-aggregates-create-update-errors",
+      "title": "Aggregate ConfigMap create/update errors during upgrade",
+      "title_zh": "Aggregate ConfigMap create/update errors during upgrade",
+      "interface_type": "workflow",
+      "interface": "worker/appm/controller.upgradeController.upgradeConfigMap",
+      "code_paths": [
+        "worker/appm/controller/upgrade.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/controller/upgrade_test.go",
+          "selector": "TestUpgradeConfigMapErrorAggregation"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.upgrade-service-aggregates-create-update-errors",
+      "title": "Aggregate Service create/update errors during upgrade",
+      "title_zh": "Aggregate Service create/update errors during upgrade",
+      "interface_type": "workflow",
+      "interface": "worker/appm/controller.upgradeController.upgradeService",
+      "code_paths": [
+        "worker/appm/controller/upgrade.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/controller/upgrade_test.go",
+          "selector": "TestUpgradeServiceErrorAggregation"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -80,6 +80,7 @@
 | rainbond.config-files.read-npmrc | 读取源码中的 npmrc 内容 | active | regression | builder/parser/code.ConfigFiles.GetNpmrcContent | builder/parser/code/config_files_test.go::TestConfigFiles_GetNpmrcContent |
 | rainbond.config-files.read-yarnrc | 读取源码中的 yarnrc 内容 | active | regression | builder/parser/code.ConfigFiles.GetYarnrcContent | builder/parser/code/config_files_test.go::TestConfigFiles_GetYarnrcContent |
 | rainbond.config-files.resolve-relevant-file | 为包管理器选择相关配置文件 | active | regression | builder/parser/code.ConfigFiles.GetRelevantConfigFile | builder/parser/code/config_files_test.go::TestConfigFiles_GetRelevantConfigFile |
+| rainbond.dockerfile-build.registry-mirror-toml | Render BuildKit TOML with optional registry mirrors | active | regression | builder/sources.buildKitTomlContent | builder/sources/buildkit_toml_test.go::TestBuildKitTomlContent<br>builder/sources/buildkit_toml_test.go::TestBuildKitTomlContentLegacyEquivalence |
 | rainbond.dockerfile.line-info | 跟踪 Dockerfile AST 的行号信息 | active | regression | util/dockerfile/parser.Parse | util/dockerfile/parser/parser_test.go::TestLineInformation |
 | rainbond.dockerfile.parse-fixtures | 将标准 Dockerfile 示例解析为稳定 AST | active | regression | util/dockerfile/parser.Parse | util/dockerfile/parser/parser_test.go::TestTestData |
 | rainbond.dockerfile.parse-json-array | 解析 Dockerfile 指令中的 JSON 数组语法 | active | regression | util/dockerfile/parser.parseJSON | util/dockerfile/parser/json_test.go::TestJSONArraysOfStrings |
@@ -278,6 +279,8 @@
 | rainbond.third-component.probe-equals | 比较第三方组件探测定义是否相等 | active | regression | pkg/apis/rainbond/v1alpha1.Probe.Equals | pkg/apis/rainbond/v1alpha1/third_component_unit_test.go::TestProbeEquals |
 | rainbond.third-component.probe-required | 判断第三方组件是否需要主动探测 | active | regression | pkg/apis/rainbond/v1alpha1.ThirdComponentSpec.NeedProbe | pkg/apis/rainbond/v1alpha1/third_component_unit_test.go::TestThirdComponentSpecNeedProbe |
 | rainbond.third-component.static-endpoints-detect | 检测第三方组件是否使用静态端点 | active | regression | pkg/apis/rainbond/v1alpha1.ThirdComponentSpec.IsStaticEndpoints | pkg/apis/rainbond/v1alpha1/third_component_unit_test.go::TestThirdComponentSpecIsStaticEndpoints |
+| rainbond.upgrade-configmap-aggregates-create-update-errors | Aggregate ConfigMap create/update errors during upgrade | active | regression | worker/appm/controller.upgradeController.upgradeConfigMap | worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapErrorAggregation |
+| rainbond.upgrade-service-aggregates-create-update-errors | Aggregate Service create/update errors during upgrade | active | regression | worker/appm/controller.upgradeController.upgradeService | worker/appm/controller/upgrade_test.go::TestUpgradeServiceErrorAggregation |
 | rainbond.util.array-deduplicate | 对字符串切片去重并保留非空元素 | active | regression | util.Deweight | util/comman_test.go::TestDeweight |
 | rainbond.util.bytes-equality | 比较字节切片是否完全相等并区分 nil 情况 | active | regression | util.BytesSliceEqual | util/bytes_test.go::TestBytesSliceEqual |
 | rainbond.util.bytes-to-string | 使用零拷贝辅助将字节切片转换为字符串 | active | regression | util.ToString | util/bytes_test.go::TestToString |
@@ -1206,6 +1209,16 @@
 - 业务入口: `builder/parser/code.ConfigFiles.GetRelevantConfigFile`
 - 代码路径: `builder/parser/code/config_files.go`
 - 测试路径: `builder/parser/code/config_files_test.go::TestConfigFiles_GetRelevantConfigFile`
+
+### Render BuildKit TOML with optional registry mirrors
+
+- Capability ID: `rainbond.dockerfile-build.registry-mirror-toml`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `builder/sources.buildKitTomlContent`
+- 代码路径: `builder/sources/image.go`
+- 测试路径: `builder/sources/buildkit_toml_test.go::TestBuildKitTomlContent`, `builder/sources/buildkit_toml_test.go::TestBuildKitTomlContentLegacyEquivalence`
 
 ### 跟踪 Dockerfile AST 的行号信息
 
@@ -3186,6 +3199,26 @@
 - 业务入口: `pkg/apis/rainbond/v1alpha1.ThirdComponentSpec.IsStaticEndpoints`
 - 代码路径: `pkg/apis/rainbond/v1alpha1/third_component.go`
 - 测试路径: `pkg/apis/rainbond/v1alpha1/third_component_unit_test.go::TestThirdComponentSpecIsStaticEndpoints`
+
+### Aggregate ConfigMap create/update errors during upgrade
+
+- Capability ID: `rainbond.upgrade-configmap-aggregates-create-update-errors`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/controller.upgradeController.upgradeConfigMap`
+- 代码路径: `worker/appm/controller/upgrade.go`
+- 测试路径: `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapErrorAggregation`
+
+### Aggregate Service create/update errors during upgrade
+
+- Capability ID: `rainbond.upgrade-service-aggregates-create-update-errors`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/controller.upgradeController.upgradeService`
+- 代码路径: `worker/appm/controller/upgrade.go`
+- 测试路径: `worker/appm/controller/upgrade_test.go::TestUpgradeServiceErrorAggregation`
 
 ### 对字符串切片去重并保留非空元素
 


### PR DESCRIPTION
## What

The `Check test manifest` CI step (`make test-manifest-check`) was failing on `main` because three managed tests carry `capability_id` markers that were never registered in `test-manifest.json`:

- `rainbond.dockerfile-build.registry-mirror-toml` — `builder/sources/buildkit_toml_test.go`
- `rainbond.upgrade-configmap-aggregates-create-update-errors` — `worker/appm/controller/upgrade_test.go`
- `rainbond.upgrade-service-aggregates-create-update-errors` — `worker/appm/controller/upgrade_test.go`

Reference failing run: https://github.com/goodrain/rainbond/actions/runs/27359033207/job/80841118118

## Changes

- **`test-manifest.json`**: register the three capabilities (interface / code_paths / tests), inserted in sorted order.
- **`test-manifest.md`**: regenerated via `scripts/manage_test_manifest.py render` to stay in sync.
- **`CLAUDE.md` / `AGENTS.md`**: document the CI-enforced test-manifest workflow so future managed tests are registered with `scripts/manage_test_manifest.py add` instead of hand-editing the manifest (which is what caused this failure).

## Test plan

- [x] `make test-manifest-check` → `test manifest validation passed for rainbond`
- [x] `python3 -c "import json; json.load(open('test-manifest.json'))"` → valid JSON
- [x] No reformatting churn: diff is additive only (+163 lines across 4 files)