### PR TITLE
fix(builder): suppress duplicate image pull progress lines in build log

### DIFF
--- a/builder/sources/image_containerd_client.go
+++ b/builder/sources/image_containerd_client.go
@@ -574,9 +574,10 @@ func (c *containerdImageCliImpl) ImageLoad(tarFile string, logger event.Logger) 
 // by checking status in the content store.
 func ShowProgress(ctx context.Context, ongoing *Jobs, cs content.Store, logger event.Logger) {
 	var (
-		ticker   = time.NewTicker(100 * time.Millisecond)
+		ticker   = time.NewTicker(500 * time.Millisecond)
 		start    = time.Now()
 		statuses = map[string]ctrcontent.StatusInfo{}
+		emitted  = map[string]ctrcontent.StatusInfo{}
 		done     bool
 	)
 	defer ticker.Stop()
@@ -664,12 +665,17 @@ outer:
 					}
 				}
 			}
-			var ordered []ctrcontent.StatusInfo
+			var changed []ctrcontent.StatusInfo
 			for _, key := range keys {
-				ordered = append(ordered, statuses[key])
+				status := statuses[key]
+				if !statusInfoChanged(emitted[key], status) {
+					continue
+				}
+				emitted[key] = status
+				changed = append(changed, status)
 			}
 
-			Display(ordered, start, logger)
+			Display(changed, start, logger)
 
 			if done {
 				//tt.Flush()
@@ -729,6 +735,14 @@ func (j *Jobs) IsResolved() bool {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	return j.resolved
+}
+
+// statusInfoChanged reports whether a status update carries new information
+// worth emitting to the event log. The progress ticker fires on a fixed
+// interval, so without this check the same "resolving"/"waiting" line would
+// be appended to the build log on every tick.
+func statusInfoChanged(prev, cur ctrcontent.StatusInfo) bool {
+	return prev.Status != cur.Status || prev.Offset != cur.Offset || prev.Total != cur.Total
 }
 
 // Display pretty prints out the download or upload progress

--- a/builder/sources/image_containerd_progress_test.go
+++ b/builder/sources/image_containerd_progress_test.go
@@ -1,0 +1,54 @@
+package sources
+
+import (
+	"testing"
+
+	ctrcontent "github.com/containerd/containerd/cmd/ctr/commands/content"
+)
+
+func TestStatusInfoChanged(t *testing.T) {
+	tests := []struct {
+		name string
+		prev ctrcontent.StatusInfo
+		cur  ctrcontent.StatusInfo
+		want bool
+	}{
+		{
+			name: "first emission for a ref",
+			prev: ctrcontent.StatusInfo{},
+			cur:  ctrcontent.StatusInfo{Ref: "img", Status: "resolving"},
+			want: true,
+		},
+		{
+			name: "unchanged resolving status is suppressed",
+			prev: ctrcontent.StatusInfo{Ref: "img", Status: "resolving"},
+			cur:  ctrcontent.StatusInfo{Ref: "img", Status: "resolving"},
+			want: false,
+		},
+		{
+			name: "status transition is emitted",
+			prev: ctrcontent.StatusInfo{Ref: "img", Status: "resolving"},
+			cur:  ctrcontent.StatusInfo{Ref: "img", Status: "downloading"},
+			want: true,
+		},
+		{
+			name: "download progress advance is emitted",
+			prev: ctrcontent.StatusInfo{Ref: "layer", Status: "downloading", Offset: 100, Total: 1000},
+			cur:  ctrcontent.StatusInfo{Ref: "layer", Status: "downloading", Offset: 200, Total: 1000},
+			want: true,
+		},
+		{
+			name: "stalled download is suppressed",
+			prev: ctrcontent.StatusInfo{Ref: "layer", Status: "downloading", Offset: 100, Total: 1000},
+			cur:  ctrcontent.StatusInfo{Ref: "layer", Status: "downloading", Offset: 100, Total: 1000},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusInfoChanged(tt.prev, tt.cur); got != tt.want {
+				t.Errorf("statusInfoChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
ShowProgress ticked every 100ms and emitted a log line for every job on every tick, flooding the event log with identical resolving/waiting lines. Only emit a line when a ref's status or offset/total actually changes, and relax the ticker to 500ms.