### PR TITLE
feat(cluster): add lightweight plugin existence probe endpoint

### DIFF
--- a/api/api/api_interface.go
+++ b/api/api/api_interface.go
@@ -50,6 +50,7 @@ type ClusterInterface interface {
 	GetRbdPods(w http.ResponseWriter, r *http.Request)
 	HistoryRbdLogs(w http.ResponseWriter, r *http.Request)
 	ListPlugins(w http.ResponseWriter, r *http.Request)
+	PluginExists(w http.ResponseWriter, r *http.Request)
 	CreateRBDPlugin(w http.ResponseWriter, r *http.Request)
 	ListAbilities(w http.ResponseWriter, r *http.Request)
 	GetAbility(w http.ResponseWriter, r *http.Request)

--- a/api/api_routers/version2/v2Routers.go
+++ b/api/api_routers/version2/v2Routers.go
@@ -292,6 +292,7 @@ func (v2 *V2) clusterRouter() chi.Router {
 	r.Post("/shell-pod", controller.GetManager().CreateShellPod)
 	r.Delete("/shell-pod", controller.GetManager().DeleteShellPod)
 	r.Get("/plugins", controller.GetManager().ListPlugins)
+	r.Get("/plugins/exists", controller.GetManager().PluginExists)
 	r.Post("/plugins", controller.GetManager().CreateRBDPlugin)
 	r.Get("/abilities", controller.GetManager().ListAbilities)
 	r.Get("/abilities/{ability_id}", controller.GetManager().GetAbility)

--- a/api/controller/cluster.go
+++ b/api/controller/cluster.go
@@ -481,6 +481,20 @@ func (c *ClusterController) ListPlugins(w http.ResponseWriter, r *http.Request) 
 	httputil.ReturnSuccess(r, w, res)
 }
 
+// PluginExists is a lightweight probe that reports whether an official plugin
+// with the given name exists in the cluster. It avoids the heavy enrichment in
+// ListPlugins so callers that only need existence (e.g. edition detection) stay
+// fast even when the worker/status service is slow.
+func (c *ClusterController) PluginExists(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	exist, err := handler.GetClusterHandler().PluginExists(name)
+	if err != nil {
+		httputil.ReturnBcodeError(r, w, err)
+		return
+	}
+	httputil.ReturnSuccess(r, w, map[string]bool{"exist": exist})
+}
+
 // CreateRBDPlugin creates an RBDPlugin CR
 func (c *ClusterController) CreateRBDPlugin(w http.ResponseWriter, r *http.Request) {
 	var req model.CreateRBDPluginReq

--- a/api/handler/cluster.go
+++ b/api/handler/cluster.go
@@ -43,6 +43,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/util/flushwriter"
@@ -92,6 +93,7 @@ type ClusterHandler interface {
 	CreateShellPod(regionName string) (pod *corev1.Pod, err error)
 	DeleteShellPod(podName string) error
 	ListPlugins(official bool) (rbds []*model.RainbondPlugins, err error)
+	PluginExists(name string) (bool, error)
 	CreatePlugin(req *model.CreateRBDPluginReq) error
 	ListAbilities() (rbds []unstructured.Unstructured, err error)
 	GetAbility(abilityID string) (rbd *unstructured.Unstructured, err error)
@@ -800,6 +802,23 @@ func (c *clusterAction) ListPlugins(official bool) (plugins []*model.RainbondPlu
 		return plugins, nil
 	}
 	return res, nil
+}
+
+// PluginExists reports whether an official plugin with the given name exists in
+// the cluster. It uses a label selector so the K8s API does the filtering and
+// skips the heavy app-status/tenant enrichment done by HandlePlugins, making it
+// a cheap probe for callers that only need existence (e.g. edition detection).
+func (c *clusterAction) PluginExists(name string) (bool, error) {
+	if name == "" {
+		return false, nil
+	}
+	selector := labels.SelectorFromSet(labels.Set{OfficialPluginLabel: name}).String()
+	list, err := c.rainbondClient.RainbondV1alpha1().RBDPlugins(metav1.NamespaceAll).List(
+		context.Background(), metav1.ListOptions{LabelSelector: selector, Limit: 1})
+	if err != nil {
+		return false, errors.Wrap(err, "list rbd plugins by name")
+	}
+	return len(list.Items) > 0, nil
 }
 
 // CreatePlugin creates or updates an RBDPlugin CR


### PR DESCRIPTION
## 背景

`rainbond-console` 的 `/console/agent/access` 接口在部分环境下需要 ~15s 才响应。根因之一是：console 为判断某个官方插件（`rainbond-enterprise-base`）是否存在，会对每个可用集群调用 `GET /v2/cluster/plugins?official=true`，而该接口（`ListPlugins` → `HandlePlugins`）会做大量富化：`ListAppStatuses`(gRPC 到 worker)、`GetALLTenants`、`ListByAppIDs` 等，调用方却只用到插件名。

## 改动

新增轻量探测接口 `GET /v2/cluster/plugins/exists?name=xxx`：

- `handler.PluginExists(name)`：用 K8s label selector（`plugin.rainbond.io/name=<name>`）+ `Limit:1` 直接判断存在性，跳过 app-status / tenant 富化。
- 配套 controller、interface、route 注册。

返回 `{"bean": {"exist": true|false}}`。

## 兼容性

纯新增接口，对现有调用零影响。旧版 console 不会调用它；新版 console 在 region 不支持时（404）回退到原 `list` 接口。

## 验证

- `go build ./api/...`：通过
- `go vet ./api/handler ./api/controller ./api/api`：通过

## 配套 PR

console 侧：goodrain/rainbond-console（`perf/agent-access-investigation`）
