### PR TITLE
ci: add @claude and @codex issue agents with cross-repo PR support

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,129 @@
+name: claude
+
+# Mention @claude in an issue or issue comment (in this repo) and Claude Code
+# will analyze the request, figure out which Rainbond repo actually needs the
+# fix (rainbond / rainbond-console / rainbond-ui), make the change, run that
+# repo's quality gate, and open a PR back-linked to the issue.
+#
+# Only members/collaborators (people with write access) can trigger it, so
+# random visitors cannot burn your Anthropic credits.
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+# Token used by the action is the GitHub App token (cross-repo). These job
+# permissions cover the action's own bookkeeping on THIS repo.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  claude:
+    # Gate: trigger phrase present AND author has write access.
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@claude') &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # 1) Mint a token that can write to ALL three repos.
+      - name: Generate cross-repo GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            rainbond
+            rainbond-console
+            rainbond-ui
+
+      # 2) Check out the triggering repo (rainbond/Go) for immediate context.
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      # 3) Make git/gh use the cross-repo token (needed to clone & push the
+      #    console / ui repos on demand).
+      - name: Configure git auth for all repos
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh auth setup-git
+
+      # 4) Run Claude in agent mode with explicit cross-repo instructions.
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          # --max-turns caps how long the agent runs => caps token spend.
+          claude_args: "--max-turns 30"
+          prompt: |
+            You are an automated engineer for the Rainbond platform. Issue
+            #${{ github.event.issue.number }} was filed in the
+            ${{ github.repository }} repository.
+
+            The Rainbond platform spans three repos under the
+            "${{ github.repository_owner }}" GitHub org:
+              - ${{ github.repository_owner }}/rainbond         (Go 1.23, core services / K8s)
+              - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, web backend)
+              - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI, frontend)
+
+            The current working directory is a checkout of the rainbond (Go) repo.
+
+            Steps:
+            1. Read the full request:
+               gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
+            2. Decide which repo(s) ACTUALLY need the fix. Do NOT assume it is
+               the Go repo — many issues filed here are really console (Python)
+               or ui (React) problems. Investigate the code before deciding.
+            3. For each repo that needs a change:
+               - If it is not the current repo, clone it:
+                   gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>
+                 then cd into it.
+               - Create branch: claude/issue-${{ github.event.issue.number }}-<short-slug>
+               - Make the MINIMAL correct change. Follow that repo's CLAUDE.md.
+               - Run the repo's quality gate BEFORE committing:
+                   * rainbond (Go):         go build ./... && go vet ./...
+                   * rainbond-console (Py): make check && pytest (relevant subset)
+                   * rainbond-ui (React):   yarn install && yarn build
+               - Commit using Conventional Commits, English, NO emoji and NO AI
+                 attribution / Co-authored-by lines.
+               - Push and open a PR:
+                   gh pr create -R ${{ github.repository_owner }}/<repo> --base main
+                 In the PR body, reference the issue:
+                   "Ref ${{ github.repository_owner }}/rainbond#${{ github.event.issue.number }}"
+            4. Comment on issue #${{ github.event.issue.number }} summarizing what
+               you did and linking the PR(s).
+
+            Hard rules:
+            - NEVER push to main. Always open a PR.
+            - If a quality gate fails and you cannot fix it, do NOT open the PR.
+              Instead comment on the issue explaining what you found and stop.
+            - Keep changes scoped to the issue. No drive-by refactors.
+            - If the issue is unclear or not reproducible, comment asking for
+              clarification instead of guessing.

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,137 @@
+name: codex
+
+# Mention @codex (instead of @claude) in an issue or comment to run the same
+# cross-repo flow with OpenAI Codex CLI, pointed at a third-party
+# OpenAI-compatible endpoint (DeepSeek / MiMo / etc.).
+#
+# NOTE: Codex CLI flags and config keys change between versions. The provider
+# block and `codex exec` flags below are a known-good shape but VERIFY them
+# against the codex version pinned in the install step before relying on it.
+#
+# Required repo config:
+#   secrets.CLAUDE_APP_ID / CLAUDE_APP_PRIVATE_KEY  (same GitHub App as claude.yml)
+#   secrets.CODEX_API_KEY                           (third-party key)
+#   vars.CODEX_BASE_URL                             (e.g. https://api.deepseek.com/v1)
+#   vars.CODEX_MODEL                                (e.g. deepseek-chat)
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  codex:
+    if: |
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@codex') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@codex') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.body, '@codex') &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Generate cross-repo GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLAUDE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            rainbond
+            rainbond-console
+            rainbond-ui
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure git auth for all repos
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh auth setup-git
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      # Point Codex at the third-party OpenAI-compatible endpoint.
+      - name: Configure Codex provider
+        env:
+          CODEX_BASE_URL: ${{ vars.CODEX_BASE_URL }}
+          CODEX_MODEL: ${{ vars.CODEX_MODEL }}
+        run: |
+          mkdir -p "$HOME/.codex"
+          cat > "$HOME/.codex/config.toml" <<EOF
+          model = "${CODEX_MODEL}"
+          model_provider = "thirdparty"
+
+          [model_providers.thirdparty]
+          name = "Third Party"
+          base_url = "${CODEX_BASE_URL}"
+          env_key = "CODEX_API_KEY"
+          EOF
+
+      - name: Run Codex
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        run: |
+          PROMPT=$(cat <<'EOF'
+          You are an automated engineer for the Rainbond platform. Issue
+          #${{ github.event.issue.number }} was filed in the
+          ${{ github.repository }} repository.
+
+          The platform spans three repos under "${{ github.repository_owner }}":
+            - ${{ github.repository_owner }}/rainbond         (Go 1.23, core / K8s)
+            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2)
+            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI)
+
+          The current directory is a checkout of the rainbond (Go) repo. GH_TOKEN
+          is set and `gh` is authenticated for all three repos.
+
+          Steps:
+          1. Read the request:
+             gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
+          2. Decide which repo(s) actually need the fix (do NOT assume Go).
+          3. For each repo needing a change: clone it if needed
+             (gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>),
+             create branch codex/issue-${{ github.event.issue.number }}-<slug>,
+             make the minimal correct change following that repo's CLAUDE.md, run
+             its quality gate (Go: go build ./... && go vet ./...; console:
+             make check && pytest; ui: yarn install && yarn build), commit
+             (Conventional Commits, English, no emoji, no AI attribution), push,
+             and open a PR: gh pr create -R ${{ github.repository_owner }}/<repo> --base main
+             referencing the issue in the body.
+          4. Comment on issue #${{ github.event.issue.number }} with a summary + PR links.
+
+          Hard rules: never push to main; if a quality gate fails and you cannot
+          fix it, do not open the PR — comment on the issue and stop; keep changes
+          scoped; ask for clarification if the issue is unclear.
+          EOF
+          )
+          # --dangerously-bypass-approvals-and-sandbox lets Codex run git/gh and
+          # reach the network in CI. Verify this flag for your codex version.
+          codex exec --dangerously-bypass-approvals-and-sandbox "$PROMPT"


### PR DESCRIPTION
Mention @claude or @codex in an issue (or comment) to have an AI agent analyze the request, determine which Rainbond repo needs the fix (rainbond / rainbond-console / rainbond-ui), run that repo's quality gate, and open a PR back-linked to the issue.

Triggers are gated to collaborators only and capped via --max-turns and timeout-minutes. Cross-repo writes use a GitHub App token.