### PR TITLE
ci: add AI issue agents (/claude /codex /mimo) with cross-repo PR support

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: claude
 
-# Mention @claude in an issue or issue comment (in this repo) and Claude Code
+# Comment "/claude" in an issue or issue comment (in this repo) and Claude Code
 # will analyze the request, figure out which Rainbond repo actually needs the
 # fix (rainbond / rainbond-console / rainbond-ui), make the change, run that
 # repo's quality gate, and open a PR back-linked to the issue.
@@ -29,17 +29,17 @@ jobs:
     # Gate: trigger phrase present AND author has write access.
     if: |
       (github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude') &&
+        contains(github.event.comment.body, '/claude') &&
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
+        contains(github.event.comment.body, '/claude') &&
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'issues' &&
-        contains(github.event.issue.body, '@claude') &&
+        contains(github.event.issue.body, '/claude') &&
         (github.event.issue.author_association == 'OWNER' ||
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
@@ -77,11 +77,34 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Third-party Anthropic-compatible endpoint. Stored as a SECRET (not a
+          # var) so a private relay domain is masked in public Actions logs.
+          # Leave the secret empty to use the official Anthropic API.
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          # Bearer-auth third parties need ANTHROPIC_AUTH_TOKEN (sent as
+          # "Authorization: Bearer ..."), which takes precedence over x-api-key.
+          # For the OFFICIAL Anthropic API leave this secret empty and instead
+          # set the ANTHROPIC_API_KEY secret below.
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Satisfies the action's auth preflight. When ANTHROPIC_AUTH_TOKEN is
+          # set above, Claude Code uses the Bearer token and ignores this.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_AUTH_TOKEN || secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          # Post a live-updating progress comment on the issue (todo checklist +
+          # current action). Better than log-watching: visible on the issue and
+          # safe on public repos (it is a comment, not secret-bearing logs).
+          track_progress: true
+          # Full transcript in the Actions log ONLY on private repos. On public
+          # repos (e.g. goodrain) this auto-disables so runtime values the agent
+          # prints are not exposed in the world-readable logs.
+          show_full_output: ${{ github.event.repository.private }}
           # --max-turns caps how long the agent runs => caps token spend.
-          claude_args: "--max-turns 30"
+          # --allowedTools lets the agent run git/gh/build commands non-interactively;
+          #   without it every Bash call is denied (permission_denials) and nothing happens.
+          # --model sets the third-party model name (e.g. deepseek-chat).
+          # Set vars.ANTHROPIC_MODEL to override; defaults to the official model.
+          claude_args: "--max-turns 50 --allowedTools Bash,Edit,MultiEdit,Write,Read,Glob,Grep,TodoWrite,WebFetch ${{ vars.ANTHROPIC_MODEL && format('--model {0}', vars.ANTHROPIC_MODEL) || '' }}"
           prompt: |
             You are an automated engineer for the Rainbond platform. Issue
             #${{ github.event.issue.number }} was filed in the
@@ -89,9 +112,18 @@ jobs:
 
             The Rainbond platform spans three repos under the
             "${{ github.repository_owner }}" GitHub org:
-              - ${{ github.repository_owner }}/rainbond         (Go 1.23, core services / K8s)
-              - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, web backend)
-              - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI, frontend)
+              - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+                (API/builder/worker); the only layer that talks to Kubernetes.
+              - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+                web backend; serves the UI and orchestrates calls to rainbond via
+                RegionInvokeApi (HTTP to /v2/tenants/...). Shares the MySQL instance
+                with rainbond but uses a separate logical DB (no shared tables).
+              - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend dashboard;
+                calls console at /console/* and /openapi/v1/*.
+
+            Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.
+            Each repo has its own CLAUDE.md and AGENTS.md with detailed conventions —
+            ALWAYS read the target repo's CLAUDE.md before changing it.
 
             The current working directory is a checkout of the rainbond (Go) repo.
 
@@ -106,13 +138,21 @@ jobs:
                    gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>
                  then cd into it.
                - Create branch: claude/issue-${{ github.event.issue.number }}-<short-slug>
+               - Where practical, FIRST add a regression test that reproduces the
+                 bug: it must FAIL before your change and PASS after. This proves
+                 the real problem is fixed, not just that existing tests pass.
+                 (Go: table test; console: pytest.) If the bug is purely
+                 visual/frontend and a meaningful automated test is impractical,
+                 say so in the PR and give manual verification steps instead.
                - Make the MINIMAL correct change. Follow that repo's CLAUDE.md.
                - Run the repo's quality gate BEFORE committing:
                    * rainbond (Go):         go build ./... && go vet ./...
                    * rainbond-console (Py): make check && pytest (relevant subset)
                    * rainbond-ui (React):   yarn install && yarn build
-               - Commit using Conventional Commits, English, NO emoji and NO AI
-                 attribution / Co-authored-by lines.
+               - Commit with `git commit -s` (the -s adds the DCO Signed-off-by
+                 trailer REQUIRED by the repo's DCO check; it matches the bot git
+                 identity and is NOT AI attribution). Use Conventional Commits,
+                 English, NO emoji and NO Co-authored-by / AI attribution lines.
                - Push and open a PR:
                    gh pr create -R ${{ github.repository_owner }}/<repo> --base main
                  In the PR body, reference the issue:

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -1,17 +1,19 @@
-name: codex
+name: mimo
 
-# Comment "/codex" (instead of "/claude") in an issue or comment to run the same
-# cross-repo flow with OpenAI Codex CLI.
+# Comment "/mimo" in an issue or comment to run the cross-repo fix flow with
+# Xiaomi's MiMo-Code agent (an OpenCode fork) driving the MiMo model natively.
+# This is the "native agent + native model" variant, to compare against claude.yml.
 #
-# IMPORTANT: current Codex only speaks the Responses API (/v1/responses). The
-# endpoint in CODEX_BASE_URL MUST support it — a Chat-Completions-only endpoint
-# (e.g. MiMo) will 404. Use OpenAI official or a Responses-API-compatible provider.
+# NOTE: MiMo-Code is an OpenCode fork; CLI binary name, config path and flags may
+# change. Verified against the repo source as of 2026-06: headless run is
+# `mimo run "<msg>"`, auto-approve is `--dangerously-skip-permissions`, custom
+# provider goes in opencode.json with npm "@ai-sdk/openai-compatible".
 #
 # Required repo config:
 #   secrets.CLAUDE_APP_ID / CLAUDE_APP_PRIVATE_KEY  (same GitHub App as claude.yml)
-#   secrets.CODEX_API_KEY                           (provider key)
-#   vars.CODEX_BASE_URL                             (Responses-API endpoint, e.g. https://api.openai.com/v1)
-#   vars.CODEX_MODEL                                (e.g. gpt-5-codex)
+#   secrets.MIMO_API_KEY                            (MiMo key)
+#   vars.MIMO_BASE_URL                              (OpenAI-compatible base, e.g. https://token-plan-cn.xiaomimimo.com/v1)
+#   vars.MIMO_MODEL                                 (e.g. mimo-v2.5)
 
 on:
   issue_comment:
@@ -27,20 +29,20 @@ permissions:
   pull-requests: write
 
 jobs:
-  codex:
+  mimo:
     if: |
       (github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '/codex') &&
+        contains(github.event.comment.body, '/mimo') &&
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '/codex') &&
+        contains(github.event.comment.body, '/mimo') &&
         (github.event.comment.author_association == 'OWNER' ||
          github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'issues' &&
-        contains(github.event.issue.body, '/codex') &&
+        contains(github.event.issue.body, '/mimo') &&
         (github.event.issue.author_association == 'OWNER' ||
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
@@ -73,34 +75,46 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install Codex CLI
-        run: npm install -g @openai/codex
+      - name: Install MiMo-Code CLI
+        run: npm install -g @mimo-ai/cli
 
-      # Point Codex at the Responses-API endpoint. base_url is a SECRET so a
-      # private relay domain stays masked in public Actions logs.
-      - name: Configure Codex provider
+      # Define the MiMo provider. apiKey uses {env:...} so the key is read at
+      # runtime and never written to the config file on disk. Written to several
+      # candidate paths because the OpenCode fork's config discovery may use
+      # either name (opencode.json / .mimocode/mimocode.json) or the global dir.
+      - name: Configure MiMo provider
         env:
-          CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
-          CODEX_MODEL: ${{ vars.CODEX_MODEL }}
+          # base_url is a SECRET so a private relay domain stays masked in logs.
+          MIMO_BASE_URL: ${{ secrets.MIMO_BASE_URL }}
+          MIMO_MODEL: ${{ vars.MIMO_MODEL }}
         run: |
-          mkdir -p "$HOME/.codex"
-          cat > "$HOME/.codex/config.toml" <<EOF
-          model = "${CODEX_MODEL}"
-          model_provider = "thirdparty"
-
-          [model_providers.thirdparty]
-          name = "Third Party"
-          base_url = "${CODEX_BASE_URL}"
-          env_key = "CODEX_API_KEY"
-          # Current Codex only supports the Responses API. The provider set in
-          # CODEX_BASE_URL MUST expose /v1/responses (a chat-only endpoint 404s).
-          wire_api = "responses"
+          read -r -d '' CFG <<EOF || true
+          {
+            "\$schema": "https://opencode.ai/config.json",
+            "provider": {
+              "mimo": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "MiMo",
+                "options": {
+                  "baseURL": "${MIMO_BASE_URL}",
+                  "apiKey": "{env:MIMO_API_KEY}"
+                },
+                "models": {
+                  "${MIMO_MODEL}": { "name": "MiMo" }
+                }
+              }
+            }
+          }
           EOF
+          mkdir -p .mimocode "$HOME/.config/opencode"
+          printf '%s\n' "$CFG" | tee opencode.json .mimocode/mimocode.json "$HOME/.config/opencode/opencode.json" >/dev/null
+          echo "provider config written (base_url hidden)"
 
-      - name: Run Codex
+      - name: Run MiMo-Code
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          MIMO_MODEL: ${{ vars.MIMO_MODEL }}
         run: |
           PROMPT=$(cat <<'EOF'
           You are an automated engineer for the Rainbond platform. Issue
@@ -129,7 +143,7 @@ jobs:
           2. Decide which repo(s) actually need the fix (do NOT assume Go).
           3. For each repo needing a change: clone it if needed
              (gh repo clone ${{ github.repository_owner }}/<repo> /tmp/<repo>),
-             create branch codex/issue-${{ github.event.issue.number }}-<slug>.
+             create branch mimo/issue-${{ github.event.issue.number }}-<slug>.
              Where practical, FIRST add a regression test that reproduces the bug
              (must FAIL before the fix, PASS after) to prove the real problem is
              fixed — not just that existing tests pass. If purely visual/frontend
@@ -148,6 +162,6 @@ jobs:
           scoped; ask for clarification if the issue is unclear.
           EOF
           )
-          # --dangerously-bypass-approvals-and-sandbox lets Codex run git/gh and
-          # reach the network in CI. Verify this flag for your codex version.
-          codex exec --dangerously-bypass-approvals-and-sandbox "$PROMPT"
+          # --dangerously-skip-permissions auto-approves tool use (bash/git/gh)
+          # so the agent can run unattended in CI.
+          mimo run "$PROMPT" --model "mimo/${MIMO_MODEL}" --dangerously-skip-permissions


### PR DESCRIPTION
## What

Adds three opt-in AI issue-fixing agents. Commenting `/claude`, `/codex` or `/mimo` on an issue makes an AI agent investigate the request, decide which Rainbond repo actually needs the fix (rainbond / rainbond-console / rainbond-ui), run that repo's quality gate, and open a cross-repo PR back-linked to the issue.

This supersedes the initial claude/codex workflows added in #2604 (hardening + adds mimo).

## Safety / cost controls

- **Trigger gated to collaborators** (OWNER/MEMBER/COLLABORATOR) — random visitors cannot trigger.
- `--max-turns` + `timeout-minutes: 30` cap every run.
- Cross-repo writes use a **GitHub App token** (not the default GITHUB_TOKEN).
- Base URLs stored as **secrets**; full agent output shown **only on private repos** (auto-off here since this repo is public).
- Agents **never push to main** — always open a PR for human review.
- Commits are **signed off (-s) for DCO**.

## Required repo configuration (admin)

Secrets: `CLAUDE_APP_ID`, `CLAUDE_APP_PRIVATE_KEY`, plus per-engine `ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_BASE_URL` (claude), `CODEX_API_KEY`/`CODEX_BASE_URL` (codex), `MIMO_API_KEY`/`MIMO_BASE_URL` (mimo).
Variables: `ANTHROPIC_MODEL`, `CODEX_MODEL`, `MIMO_MODEL`.
A GitHub App (Contents/Issues/PRs R&W) must be installed on rainbond, rainbond-console and rainbond-ui.

Engines with unconfigured secrets simply fail fast and can be disabled individually.

Validated end-to-end on a fork (all three engines correctly routed a UI bug filed in this repo to rainbond-ui and opened a PR).