### PR TITLE
ci: add PR mode so agents can fix an existing PR in place

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       # 1) Mint a token that can write to ALL three repos.
       - name: Generate cross-repo GitHub App token
@@ -118,7 +118,7 @@ jobs:
           #   without it every Bash call is denied (permission_denials) and nothing happens.
           # --model sets the third-party model name (e.g. deepseek-chat).
           # Set vars.ANTHROPIC_MODEL to override; defaults to the official model.
-          claude_args: "--max-turns 50 --allowedTools Bash,Edit,MultiEdit,Write,Read,Glob,Grep,TodoWrite,WebFetch ${{ vars.ANTHROPIC_MODEL && format('--model {0}', vars.ANTHROPIC_MODEL) || '' }}"
+          claude_args: "--max-turns 120 --allowedTools Bash,Edit,MultiEdit,Write,Read,Glob,Grep,TodoWrite,WebFetch ${{ vars.ANTHROPIC_MODEL && format('--model {0}', vars.ANTHROPIC_MODEL) || '' }}"
           prompt: |
             You are an automated engineer for the Rainbond platform. Issue
             #${{ github.event.issue.number }} was filed in the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -126,13 +126,13 @@ jobs:
 
             The Rainbond platform spans three repos under the
             "${{ github.repository_owner }}" GitHub org:
-              - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+              - ${{ github.repository_owner }}/rainbond         (Go, port 8443) core services
                 (API/builder/worker); the only layer that talks to Kubernetes.
-              - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+              - ${{ github.repository_owner }}/rainbond-console (Python / Django, port 7070)
                 web backend; serves the UI and orchestrates calls to rainbond via
                 RegionInvokeApi (HTTP to /v2/tenants/...). Shares the MySQL instance
                 with rainbond but uses a separate logical DB (no shared tables).
-              - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend dashboard;
+              - ${{ github.repository_owner }}/rainbond-ui      (React / UMI) frontend dashboard;
                 calls console at /console/* and /openapi/v1/*.
 
             Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,6 +22,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: read      # read CI run logs in PR mode (fix failing checks)
+  checks: read       # read PR check status in PR mode
   id-token: write
 
 jobs:
@@ -140,6 +142,25 @@ jobs:
             The current working directory is a checkout of the rainbond (Go) repo.
 
             Steps:
+            0. Determine context. Run:
+                 gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+               If #${{ github.event.issue.number }} IS a pull request, use PR MODE
+               below and STOP (skip the issue steps). Otherwise it is an issue —
+               continue at step 1.
+
+            PR MODE (iterate on THIS existing PR — never open a new PR):
+               - Check out the PR branch:
+                   gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
+               - Do what the comment asks. If asked to fix failing CI:
+                   gh pr checks ${{ github.event.issue.number }} --repo ${{ github.repository }}
+                 open the failing check's logs (e.g. gh run view --log --job=<id>),
+                 find the real cause, and fix it.
+               - Set the bot identity (git config user.name "$BOT_NAME";
+                 git config user.email "$BOT_EMAIL"), then `git commit -s` and
+                 `git push` to the SAME PR branch. Do NOT create a new branch or PR.
+               - Comment on the PR with a short summary of what you changed.
+
+            ISSUE MODE:
             1. Read the full request and the triggering comment:
                gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
             2. Pick a MODE based on what is actually being asked:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -119,12 +119,12 @@ jobs:
           ${{ github.repository }} repository.
 
           The platform spans three repos under "${{ github.repository_owner }}":
-            - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+            - ${{ github.repository_owner }}/rainbond         (Go, port 8443) core services
               (API/builder/worker); only layer that talks to Kubernetes.
-            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+            - ${{ github.repository_owner }}/rainbond-console (Python / Django, port 7070)
               web backend; serves UI, orchestrates rainbond via RegionInvokeApi
               (/v2/tenants/...). Same MySQL instance, separate logical DB.
-            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend;
+            - ${{ github.repository_owner }}/rainbond-ui      (React / UMI) frontend;
               calls console at /console/* and /openapi/v1/*.
 
           Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -47,7 +47,7 @@ jobs:
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Generate cross-repo GitHub App token
         id: app-token

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -25,6 +25,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: read      # read CI run logs in PR mode (fix failing checks)
+  checks: read       # read PR check status in PR mode
 
 jobs:
   codex:
@@ -133,6 +135,20 @@ jobs:
           is set and `gh` is authenticated for all three repos.
 
           Steps:
+          0. Run: gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             If #${{ github.event.issue.number }} IS a pull request, use PR MODE and
+             STOP. Otherwise continue at step 1 (issue).
+
+          PR MODE (iterate on THIS PR, never open a new one):
+             - gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             - Do what the comment asks; to fix CI: gh pr checks
+               ${{ github.event.issue.number }} --repo ${{ github.repository }}, read the
+               failing job logs, fix the cause.
+             - Set identity (git config user.name "$BOT_NAME"; git config user.email
+               "$BOT_EMAIL"), git commit -s, git push to the SAME branch. No new PR.
+             - Comment on the PR with a summary.
+
+          ISSUE MODE:
           1. Read the request and the triggering comment:
              gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
           2. Pick a MODE:

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -133,12 +133,12 @@ jobs:
           ${{ github.repository }} repository.
 
           The platform spans three repos under "${{ github.repository_owner }}":
-            - ${{ github.repository_owner }}/rainbond         (Go 1.23, port 8443) core services
+            - ${{ github.repository_owner }}/rainbond         (Go, port 8443) core services
               (API/builder/worker); only layer that talks to Kubernetes.
-            - ${{ github.repository_owner }}/rainbond-console (Python 3.6 / Django 2.2, port 7070)
+            - ${{ github.repository_owner }}/rainbond-console (Python / Django, port 7070)
               web backend; serves UI, orchestrates rainbond via RegionInvokeApi
               (/v2/tenants/...). Same MySQL instance, separate logical DB.
-            - ${{ github.repository_owner }}/rainbond-ui      (React 16.8 / UMI) frontend;
+            - ${{ github.repository_owner }}/rainbond-ui      (React / UMI) frontend;
               calls console at /console/* and /openapi/v1/*.
 
           Request flow: rainbond-ui -> rainbond-console -> rainbond -> Kubernetes.

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -49,7 +49,7 @@ jobs:
          github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Generate cross-repo GitHub App token
         id: app-token

--- a/.github/workflows/mimo.yml
+++ b/.github/workflows/mimo.yml
@@ -27,6 +27,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  actions: read      # read CI run logs in PR mode (fix failing checks)
+  checks: read       # read PR check status in PR mode
 
 jobs:
   mimo:
@@ -147,6 +149,20 @@ jobs:
           is set and `gh` is authenticated for all three repos.
 
           Steps:
+          0. Run: gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             If #${{ github.event.issue.number }} IS a pull request, use PR MODE and
+             STOP. Otherwise continue at step 1 (issue).
+
+          PR MODE (iterate on THIS PR, never open a new one):
+             - gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
+             - Do what the comment asks; to fix CI: gh pr checks
+               ${{ github.event.issue.number }} --repo ${{ github.repository }}, read the
+               failing job logs, fix the cause.
+             - Set identity (git config user.name "$BOT_NAME"; git config user.email
+               "$BOT_EMAIL"), git commit -s, git push to the SAME branch. No new PR.
+             - Comment on the PR with a summary.
+
+          ISSUE MODE:
           1. Read the request and the triggering comment:
              gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --comments
           2. Pick a MODE:


### PR DESCRIPTION
When an agent is triggered by a comment on a PULL REQUEST (not an issue), it now:
- checks out the PR branch (gh pr checkout)
- does what the comment asks — e.g. reads failing CI (gh pr checks + logs) and fixes the cause
- commits (bot identity, signed off) and pushes to the SAME PR branch — no new PR
- comments a summary

Lets you iterate on an agent's PR directly: e.g. `/claude fix the CI`.

Adds `actions: read` and `checks: read` permissions (needed to read run logs / check status). NOTE: the GitHub App must also be granted **Actions: Read** and **Checks: Read** for log/status reading to work.

Requires the workflows to also exist in the repo where the PR lives (separate PRs add them to rainbond-console and rainbond-ui).

Signed-off-by present (DCO).