### PR TITLE
fix: normalize gateway/route error handling for user-facing flows

### DIFF
--- a/api/controller/apigateway/api_gateway_route.go
+++ b/api/controller/apigateway/api_gateway_route.go
@@ -84,6 +84,7 @@ func (g Struct) OpenOrCloseDomains(w http.ResponseWriter, r *http.Request) {
 			}
 			logrus.Errorf("update route %v failure: %v", item.Name, err)
 			httputil.ReturnBcodeError(r, w, bcode.ErrRouteUpdate)
+			return
 		}
 	}
 	httputil.ReturnSuccess(r, w, nil)
@@ -579,7 +580,9 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 			},
 			Spec: spec,
 		}
-		for {
+		const maxRetries = 100
+		serviceCreated := false
+		for retryCount := 0; retryCount < maxRetries; retryCount++ {
 			// 设置服务的 NodePort
 			nodePort := service.Spec.Ports[0].NodePort
 			// 创建服务
@@ -598,14 +601,20 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 				} else {
 					// 其他错误，返回失败
 					logrus.Errorf("create tcp rule func, create svc failure: %s", err.Error())
-					httputil.ReturnBcodeError(r, w, fmt.Errorf("create tcp rule func, create svc failure: %s", err.Error()))
+					httputil.ReturnBcodeError(r, w, bcode.ErrServiceCreate)
 					return
 				}
 			}
 			apisixRouteStream.Match.IngressPort = nodePort
 			// 如果创建成功，退出循环
 			logrus.Infof("Service created successfully with NodePort %d", nodePort)
+			serviceCreated = true
 			break
+		}
+		if !serviceCreated {
+			logrus.Errorf("failed to create TCP route after %d retries", maxRetries)
+			httputil.ReturnBcodeError(r, w, bcode.ErrPortExists)
+			return
 		}
 	} else {
 		// Service exists, update it

--- a/api/util/bcode/api_gateway.go
+++ b/api/util/bcode/api_gateway.go
@@ -66,15 +66,15 @@ var (
 	ErrRouteNotFound = newByMessage(http.StatusNotFound, RouteNotFound, "route not found")
 
 	// ErrRouteExist 标识路由已存在
-	ErrRouteExist = newByMessage(http.StatusBadRequest, RouteExists, "路由地址已存在")
+	ErrRouteExist = newByMessage(http.StatusBadRequest, RouteExists, "route already exists")
 
 	// ErrRouteUpdate 表示路由更新错误
-	ErrRouteUpdate = newByMessage(http.StatusBadRequest, RouteUpdateError, "路由更新错误,请检查参数")
+	ErrRouteUpdate = newByMessage(http.StatusBadRequest, RouteUpdateError, "route update error, please check parameters")
 
-	ErrPortExists = newByMessage(http.StatusBadRequest, RouteCreateErrorPortExists, "端口已经被占用,请更换端口")
+	ErrPortExists = newByMessage(http.StatusBadRequest, RouteCreateErrorPortExists, "port is already in use, please use a different port")
 
 	// ErrRouteCreate 表示路由创建错误
-	ErrRouteCreate = newByMessage(http.StatusBadRequest, RouteCreateError, "路由创建错误,请检查参数")
+	ErrRouteCreate = newByMessage(http.StatusBadRequest, RouteCreateError, "route creation error, please check parameters")
 
 	// ErrRouteDelete 表示路由删除错误
 	ErrRouteDelete = newByMessage(http.StatusBadRequest, RouteDeleteError, "route delete error")


### PR DESCRIPTION
Ref goodrain/rainbond#2615

## Changes

- Return structured bcode errors instead of raw errors in CreateTCPRoute
- Add missing return statement in OpenOrCloseDomains after error
- Add retry limit (100) for TCP port conflict resolution loop
- Standardize error messages to English

## Impact

Fixes user-facing errors in:
- TCP gateway rule creation (RAINBOND-UI-T)
- Route update operations (RAINBOND-CONSOLE-7)
- Port conflict resolution (RAINBOND-CONSOLE-1G)

Generated with [Claude Code](https://claude.ai/code)