### PR TITLE
fix: prevent nil pointer dereference panics in region handler

### DIFF
--- a/api/handler/covert_resource.go
+++ b/api/handler/covert_resource.go
@@ -50,6 +50,10 @@ func (c *clusterAction) workloadDeployments(dmNames []string, namespace string) 
 			logrus.Errorf("Failed to get Deployment %v:%v", dmName, err)
 			return nil
 		}
+		if len(resources.Spec.Template.Spec.Containers) == 0 {
+			logrus.Errorf("Deployment %v has no containers, skipping", dmName)
+			continue
+		}
 		memory, cpu := resources.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value(), resources.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 		if memory == 0 {
 			memory = resources.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()
@@ -87,6 +91,10 @@ func (c *clusterAction) workloadStateFulSets(stsNames []string, namespace string
 			logrus.Errorf("Failed to get Deployment %v:%v", stsName, err)
 			return nil
 		}
+		if len(resources.Spec.Template.Spec.Containers) == 0 {
+			logrus.Errorf("StatefulSet %v has no containers, skipping", stsName)
+			continue
+		}
 		memory, cpu := resources.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value(), resources.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 		if memory == 0 {
 			memory = resources.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()
@@ -123,6 +131,10 @@ func (c *clusterAction) workloadJobs(jobNames []string, namespace string) []mode
 		if err != nil {
 			logrus.Errorf("Failed to get Deployment %v:%v", jobName, err)
 			return nil
+		}
+		if len(resources.Spec.Template.Spec.Containers) == 0 {
+			logrus.Errorf("Job %v has no containers, skipping", jobName)
+			continue
 		}
 		var BackoffLimit, Parallelism, ActiveDeadlineSeconds, Completions string
 		if resources.Spec.BackoffLimit != nil {
@@ -181,6 +193,10 @@ func (c *clusterAction) workloadCronJobs(cjNames []string, namespace string) []m
 		if err != nil {
 			logrus.Errorf("Failed to get Deployment %v:%v", cjName, err)
 			return nil
+		}
+		if len(resources.Spec.JobTemplate.Spec.Template.Spec.Containers) == 0 {
+			logrus.Errorf("CronJob %v has no containers, skipping", cjName)
+			continue
 		}
 		BackoffLimit, Parallelism, ActiveDeadlineSeconds, Completions := "", "", "", ""
 		if resources.Spec.JobTemplate.Spec.BackoffLimit != nil {

--- a/api/handler/handler.go
+++ b/api/handler/handler.go
@@ -40,6 +40,7 @@ func InitAPIHandle() error {
 		return err
 	}
 	defaultGatewayHandler = CreateGatewayManager()
+	defaultAPIGatewayHandler = CreateGatewayManager()
 	def3rdPartySvcHandler = Create3rdPartySvcHandler()
 	operationHandler = CreateOperationHandler()
 	batchOperationHandler = CreateBatchOperationHandler(operationHandler)

--- a/api/handler/resource.go
+++ b/api/handler/resource.go
@@ -72,6 +72,10 @@ func (c *clusterAction) GetAppK8SResource(ctx context.Context, namespace, appID,
 	}
 	resourceObjects := c.HandleResourceYaml([]byte(rs.Content), namespace, "get", name, nil)
 
+	if len(resourceObjects) == 0 {
+		return dbmodel.K8sResource{}, &util.APIHandleError{Code: 400, Err: fmt.Errorf("no resource objects returned for %v", name)}
+	}
+
 	if resourceObjects[0].State != model.GetError {
 		rs.Content, _ = ObjectToJSONORYaml("yaml", resourceObjects[0].Resource)
 	}
@@ -87,6 +91,11 @@ func (c *clusterAction) UpdateAppK8SResource(ctx context.Context, namespace, app
 		return dbmodel.K8sResource{}, &util.APIHandleError{Code: 400, Err: fmt.Errorf("get k8s resource %v", err)}
 	}
 	resourceObjects := c.HandleResourceYaml([]byte(resourceYaml), namespace, "update", name, map[string]string{"app_id": appID})
+
+	if len(resourceObjects) == 0 {
+		return dbmodel.K8sResource{}, &util.APIHandleError{Code: 400, Err: fmt.Errorf("no resource objects returned for %v", name)}
+	}
+
 	var rsYaml string
 	if resourceObjects[0].State == model.UpdateError {
 		rsYaml = resourceYaml

--- a/api/handler/yaml_resource.go
+++ b/api/handler/yaml_resource.go
@@ -360,6 +360,10 @@ func HandleDetailResource(namespace string, k8sResourceObjects []apimodel.K8sRes
 				deployJSON, _ := json.Marshal(buildResource.Resource)
 				var deployObject appv1.Deployment
 				json.Unmarshal(deployJSON, &deployObject)
+				if len(deployObject.Spec.Template.Spec.Containers) == 0 {
+					logrus.Errorf("Deployment %v has no containers, skipping", buildResource.Resource.GetName())
+					continue
+				}
 				memory, cpu := deployObject.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value(), deployObject.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 				if memory == 0 {
 					memory = deployObject.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()
@@ -390,6 +394,10 @@ func HandleDetailResource(namespace string, k8sResourceObjects []apimodel.K8sRes
 				jobJSON, _ := json.Marshal(buildResource.Resource)
 				var jobObject batchv1.Job
 				json.Unmarshal(jobJSON, &jobObject)
+				if len(jobObject.Spec.Template.Spec.Containers) == 0 {
+					logrus.Errorf("Job %v has no containers, skipping", buildResource.Resource.GetName())
+					continue
+				}
 				memory, cpu := jobObject.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value(), jobObject.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 				if memory == 0 {
 					memory = jobObject.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()
@@ -420,6 +428,10 @@ func HandleDetailResource(namespace string, k8sResourceObjects []apimodel.K8sRes
 				cjJSON, _ := json.Marshal(buildResource.Resource)
 				var cjObject batchv1.CronJob
 				json.Unmarshal(cjJSON, &cjObject)
+				if len(cjObject.Spec.JobTemplate.Spec.Template.Spec.Containers) == 0 {
+					logrus.Errorf("CronJob %v has no containers, skipping", buildResource.Resource.GetName())
+					continue
+				}
 				memory, cpu := cjObject.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value(), cjObject.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 				if memory == 0 {
 					memory = cjObject.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()
@@ -450,6 +462,10 @@ func HandleDetailResource(namespace string, k8sResourceObjects []apimodel.K8sRes
 				stsJSON, _ := json.Marshal(buildResource.Resource)
 				var stsObject appv1.StatefulSet
 				json.Unmarshal(stsJSON, &stsObject)
+				if len(stsObject.Spec.Template.Spec.Containers) == 0 {
+					logrus.Errorf("StatefulSet %v has no containers, skipping", buildResource.Resource.GetName())
+					continue
+				}
 				memory, cpu := stsObject.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value(), stsObject.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 				if memory == 0 {
 					memory = stsObject.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().Value()


### PR DESCRIPTION
Fixes multiple nil pointer dereference vulnerabilities that could cause panics in the rainbond-region service.

Ref goodrain/rainbond#2610

Generated with [Claude Code](https://claude.ai/code)