### PR TITLE
ci: pull allinone python base from GHCR mirror to avoid Docker Hub 429

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -338,6 +338,8 @@ jobs:
             RAINBOND_ERROR_REPORTING_FRONTEND_DSN=${{ secrets.RAINBOND_ERROR_REPORTING_FRONTEND_DSN }}
             RAINBOND_ERROR_REPORTING_CONSOLE_DSN=${{ secrets.RAINBOND_ERROR_REPORTING_CONSOLE_DSN }}
             RAINBOND_ERROR_REPORTING_BACKEND_DSN=${{ secrets.RAINBOND_ERROR_REPORTING_BACKEND_DSN }}
+            PYTHON_BASE=ghcr.io/goodrain/python:3.11-bookworm
+            PYTHON_SLIM_BASE=ghcr.io/goodrain/python:3.11-slim-bookworm
           context: .
           file: ./Dockerfile
           push: true


### PR DESCRIPTION
## Why

`dev-build` (allinone image) repeatedly hits Docker Hub's pull-rate limit (429) on `python:3.11-slim-bookworm` / `python:3.11-bookworm`. The build already authenticates to Docker Hub, but the authenticated account's free quota (200 pulls / 6h) is exhausted by repeated builds on GitHub-hosted `ubuntu-latest` runners.

## What

Override `PYTHON_BASE` / `PYTHON_SLIM_BASE` (the build args added in goodrain/rainbond-console#2004) for the allinone build, pointing them at a GHCR mirror:

```
PYTHON_BASE=ghcr.io/goodrain/python:3.11-bookworm
PYTHON_SLIM_BASE=ghcr.io/goodrain/python:3.11-slim-bookworm
```

GHCR is unmetered and fast from GitHub Actions, so dev-build stops pulling python base from Docker Hub entirely. Only the dev allinone build is affected; everything else is unchanged.

## Prerequisites / merge order
1. **Merge goodrain/rainbond-console#2004 first** (adds the `PYTHON_BASE` args; defaults stay Docker Hub so it's a no-op until used).
2. **Mirror the two images into `ghcr.io/goodrain` and make them public** (one-time):
   ```
   for t in 3.11-bookworm 3.11-slim-bookworm; do
     docker pull python:$t
     docker tag  python:$t ghcr.io/goodrain/python:$t
     docker push ghcr.io/goodrain/python:$t
   done
   # then set both packages' visibility to Public in the goodrain GHCR package settings
   ```
3. **Then merge this PR.** (If you prefer to keep the GHCR packages private, add a `docker/login-action` step for ghcr.io before the build — I can amend it.)

Note: if you'd rather mirror into the existing Aliyun registry (already wired in this workflow) instead of GHCR, just change the two values to `registry.cn-hangzhou.aliyuncs.com/goodrain/python:*` — same effect, slower pull from US runners.