### PR TITLE
ci: add one-off workflow to mirror python base images to GHCR

### DIFF
--- a/.github/workflows/mirror-python-base.yml
+++ b/.github/workflows/mirror-python-base.yml
@@ -1,0 +1,49 @@
+name: mirror-python-base-to-ghcr
+
+# 一次性/按需：把 python base 镜像从 Docker Hub 镜像到 GHCR (ghcr.io/goodrain)，
+# 供 dev-build 的 allinone 构建 FROM 拉取，规避 Docker Hub 拉取限速 (429)。
+# 跑在 GitHub 托管 runner（拉 docker.io 快、推 ghcr 是内网级），GHCR 推送用内置
+# GITHUB_TOKEN（无需 PAT）。**跑完去 GHCR 包设置把 goodrain/python 包设为 Public**，
+# dev-build 才能匿名 FROM 拉取（dev-build 未对 ghcr 登录）。
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: '要镜像的 python tag（空格分隔）'
+        required: false
+        default: '3.11-bookworm 3.11-slim-bookworm'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror python base images to ghcr.io/goodrain
+        env:
+          TAGS: ${{ github.event.inputs.tags }}
+        run: |
+          set -euo pipefail
+          for t in $TAGS; do
+            src="python:${t}"
+            dst="ghcr.io/goodrain/python:${t}"
+            echo "::group::mirror ${src} -> ${dst}"
+            docker buildx imagetools create --tag "${dst}" "${src}"
+            docker buildx imagetools inspect "${dst}" | grep -i 'linux/amd64' \
+              || { echo "ERROR: linux/amd64 missing in ${dst}"; exit 1; }
+            echo "::endgroup::"
+          done
+          echo "done. 记得到 GHCR 包设置把 goodrain/python 包设为 Public（dev-build 才能匿名拉取）。"


### PR DESCRIPTION
## Why (urgent)

#2004 (console Dockerfile `ARG PYTHON_BASE`) and #2633 (dev-build passes `ghcr.io/goodrain/python:*`) are merged, but the GHCR images **do not exist yet** — so `dev-build` currently fails at `FROM ghcr.io/goodrain/python:3.11-slim-bookworm`. This workflow mirrors those images so dev-build works again.

## What

A manually-dispatched (`workflow_dispatch`) job that copies `python:3.11-bookworm` and `python:3.11-slim-bookworm` from Docker Hub to `ghcr.io/goodrain/python:*` using `docker buildx imagetools create` (registry→registry, multi-arch preserved). Runs on a GitHub-hosted runner — fast to docker.io, native to GHCR — and pushes with the built-in `GITHUB_TOKEN` (no PAT). Verifies `linux/amd64` is present.

## How to use (after merge)
1. Merge this PR (workflow_dispatch needs the file on the default branch).
2. Run it: Actions → "mirror-python-base-to-ghcr" → Run workflow (or `gh workflow run mirror-python-base.yml -R goodrain/rainbond`).
3. **Set both `goodrain/python` packages to Public** in the org's GHCR package settings — dev-build pulls them anonymously (it doesn't log into ghcr.io).
4. dev-build is unblocked.

Reusable for future re-mirrors when the python base bumps (pass new tags via the input).

> Faster interim unblock without waiting on this: on any box with docker + a `write:packages` PAT, `docker pull --platform linux/amd64 python:3.11-bookworm && docker tag ... ghcr.io/goodrain/python:3.11-bookworm && docker push ...` (amd64-only is enough for the amd64 dev-build), then set the packages public.