### PR TITLE
ci: use GHCR_PAT for the mirror workflow GHCR login

### DIFF
--- a/.github/workflows/mirror-python-base.yml
+++ b/.github/workflows/mirror-python-base.yml
@@ -2,9 +2,11 @@ name: mirror-python-base-to-ghcr
 
 # 一次性/按需：把 python base 镜像从 Docker Hub 镜像到 GHCR (ghcr.io/goodrain)，
 # 供 dev-build 的 allinone 构建 FROM 拉取，规避 Docker Hub 拉取限速 (429)。
-# 跑在 GitHub 托管 runner（拉 docker.io 快、推 ghcr 是内网级），GHCR 推送用内置
-# GITHUB_TOKEN（无需 PAT）。**跑完去 GHCR 包设置把 goodrain/python 包设为 Public**，
-# dev-build 才能匿名 FROM 拉取（dev-build 未对 ghcr 登录）。
+# 跑在 GitHub 托管 runner（拉 docker.io 快、推 ghcr 是内网级）。GHCR 推送用 secret
+# GHCR_PAT（goodrain 成员、write:packages 的 PAT）——内置 GITHUB_TOKEN 无法在组织下
+# 新建 GHCR 包（permission_denied: write_package），故首次建包必须用 PAT。
+# **跑完去 GHCR 包设置把 goodrain/python 包设为 Public**，dev-build 才能匿名 FROM 拉取
+# （dev-build 未对 ghcr 登录）。
 
 on:
   workflow_dispatch:
@@ -30,7 +32,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Mirror python base images to ghcr.io/goodrain
         env:


### PR DESCRIPTION
## Why

The first run of `mirror-python-base-to-ghcr` failed:

```
denied: permission_denied: write_package   (403, pushing to ghcr.io/goodrain/python)
```

`GITHUB_TOKEN` cannot **create** a new org-level GHCR package — it can only write to packages that already exist and are linked to the repo. Creating `ghcr.io/goodrain/python` needs a PAT from a goodrain member with `write:packages`.

## What

Switch the GHCR login step from `secrets.GITHUB_TOKEN` to `secrets.GHCR_PAT`.

## Action needed before re-running
1. Create a PAT (classic: scope `write:packages`; or fine-grained: `packages: write` on the goodrain org) belonging to a goodrain org member.
2. Add it as a repo (or org) **secret named `GHCR_PAT`** in goodrain/rainbond.
3. Merge this PR, then re-run the workflow.
4. After it succeeds, set the two `goodrain/python` packages **Public** so dev-build can pull them anonymously.

(Once the package exists and is linked to the repo, `GITHUB_TOKEN` would also work for future re-mirrors, but using the PAT keeps it self-contained.)