### PR TITLE
ci: log in to GHCR in allinone build to pull private python mirror

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -320,6 +320,15 @@ jobs:
           username: ${{ secrets.DOMESTIC_DOCKER_USERNAME }}
           password: ${{ secrets.DOMESTIC_DOCKER_PASSWORD }}
 
+      # Pull the python base from the private ghcr.io/goodrain mirror (org policy
+      # disallows public packages), avoiding Docker Hub pull-rate (429) limits.
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
       - name: Set release description
         run: |
           buildTime=$(date +%F-%H)


### PR DESCRIPTION
## Why

The python base images were mirrored to `ghcr.io/goodrain/python` (#2637/#2638 + a mirror run), but the **goodrain org disallows public/internal packages** — so the package stays **Private**. dev-build pulls `FROM ghcr.io/goodrain/python:*` anonymously and would fail with **401**.

## What

Add a `Login to GHCR` step (using the existing `GHCR_PAT` secret) to the allinone build, before `Build and push`, so buildx authenticates to ghcr.io and can pull the private python base.

This completes the 429 fix chain:
- console Dockerfile `ARG PYTHON_BASE` (rainbond-console#2004) ✓
- dev-build passes `ghcr.io/goodrain/python:*` (#2633) ✓
- python images mirrored to GHCR (#2637/#2638 + run) ✓
- **dev-build can pull the private mirror (this PR)** ✓

After merge, dev-build no longer pulls python base from Docker Hub → no more 429.