### PR TITLE
fix: keep gateway certificate resources consistent

### DIFF
--- a/api/handler/gateway_action.go
+++ b/api/handler/gateway_action.go
@@ -54,13 +54,14 @@ import (
 
 // GatewayAction -
 type GatewayAction struct {
-	dbmanager     db.Manager
-	mqclient      client.MQClient
-	gatewayClient *gateway.GatewayV1beta1Client
-	kubeClient    kubernetes.Interface
-	kubeClientset *kubernetes.Clientset
-	config        *rest.Config
-	apisixClient  *apisixversioned.Clientset
+	dbmanager             db.Manager
+	mqclient              client.MQClient
+	gatewayClient         *gateway.GatewayV1beta1Client
+	kubeClient            kubernetes.Interface
+	kubeClientset         *kubernetes.Clientset
+	config                *rest.Config
+	apisixClient          apisixversioned.Interface
+	domainConflictChecker func(context.Context, []v2.HostType, string, string) error
 }
 
 // CreateGatewayManager creates gateway manager.
@@ -77,7 +78,7 @@ func CreateGatewayManager() *GatewayAction {
 }
 
 // GetClient -
-func (g *GatewayAction) GetClient() *apisixversioned.Clientset {
+func (g *GatewayAction) GetClient() apisixversioned.Interface {
 	return g.apisixClient
 }
 
@@ -145,134 +146,150 @@ func (g *GatewayAction) BatchGetGatewayHTTPRoute(namespace, appID string) ([]*ap
 
 // AddGatewayCertificate create gateway certificate
 func (g *GatewayAction) AddGatewayCertificate(req *apimodel.GatewayCertificate) error {
-	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       apimodel.Secret,
-			APIVersion: controller.APIVersionSecret,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.Name,
-			Namespace: req.Namespace,
-		},
-		Data: map[string][]byte{
-			"tls.crt": []byte(req.Certificate),
-			"tls.key": []byte(req.PrivateKey),
-		},
-		Type: corev1.SecretTypeTLS,
-	}
-	_, err := g.kubeClient.CoreV1().Secrets(req.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
-	if err != nil {
-		if k8serror.IsAlreadyExists(err) {
-			_, err = g.kubeClient.CoreV1().Secrets(req.Namespace).Update(context.Background(), secret, metav1.UpdateOptions{})
-			if err != nil {
-				logrus.Errorf("update gateway certificate secret failure: %v", err)
-				return err
-			}
-		}
-		logrus.Errorf("add gateway certificate secret failure: %v", err)
-		return err
-	}
-	return nil
+	return g.reconcileGatewayCertificate(req)
 }
 
 // UpdateGatewayCertificate update gateway certificate
 func (g *GatewayAction) UpdateGatewayCertificate(req *apimodel.GatewayCertificate) error {
-	secret, err := g.kubeClient.CoreV1().Secrets(req.Namespace).Get(context.Background(), req.Name, metav1.GetOptions{})
-	if err != nil {
-		if k8serror.IsNotFound(err) {
-			secret, err = g.kubeClient.CoreV1().Secrets(req.Namespace).Create(context.Background(), &corev1.Secret{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       apimodel.Secret,
-					APIVersion: controller.APIVersionSecret,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      req.Name,
-					Namespace: req.Namespace,
-				},
-				Data: map[string][]byte{
-					"tls.crt": []byte(req.Certificate),
-					"tls.key": []byte(req.PrivateKey),
-				},
-				Type: corev1.SecretTypeTLS,
-			}, metav1.CreateOptions{})
-			if err != nil {
-				logrus.Errorf("get gateway certificate secret, add failure: %v", err)
-				return err
-			}
-			return nil
+	return g.reconcileGatewayCertificate(req)
+}
+
+func (g *GatewayAction) reconcileGatewayCertificate(req *apimodel.GatewayCertificate) (retErr error) {
+	ctx := context.Background()
+	secrets := g.kubeClient.CoreV1().Secrets(req.Namespace)
+	desiredData := map[string][]byte{
+		corev1.TLSCertKey:       []byte(req.Certificate),
+		corev1.TLSPrivateKeyKey: []byte(req.PrivateKey),
+	}
+
+	currentSecret, err := secrets.Get(ctx, req.Name, metav1.GetOptions{})
+	var previousSecret *corev1.Secret
+	var persistedSecret *corev1.Secret
+	secretCreated := false
+	switch {
+	case k8serror.IsNotFound(err):
+		persistedSecret, err = secrets.Create(ctx, &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apimodel.Secret,
+				APIVersion: controller.APIVersionSecret,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      req.Name,
+				Namespace: req.Namespace,
+			},
+			Data: desiredData,
+			Type: corev1.SecretTypeTLS,
+		}, metav1.CreateOptions{})
+		if err != nil {
+			logrus.Errorf("create gateway certificate secret failure: %v", err)
+			return err
 		}
-		logrus.Errorf("update gateway certificate secret, get failure: %v", err)
+		secretCreated = true
+	case err != nil:
+		logrus.Errorf("get gateway certificate secret failure: %v", err)
 		return err
+	default:
+		previousSecret = currentSecret.DeepCopy()
+		updatedSecret := currentSecret.DeepCopy()
+		updatedSecret.Data = desiredData
+		updatedSecret.Type = corev1.SecretTypeTLS
+		persistedSecret, err = secrets.Update(ctx, updatedSecret, metav1.UpdateOptions{})
+		if err != nil {
+			logrus.Errorf("update gateway certificate secret failure: %v", err)
+			return err
+		}
 	}
-	certificate := make(map[string][]byte)
-	certificate["tls.crt"] = []byte(req.Certificate)
-	certificate["tls.key"] = []byte(req.PrivateKey)
-	secret.Data = certificate
-	secret, err = g.kubeClient.CoreV1().Secrets(req.Namespace).Update(context.Background(), secret, metav1.UpdateOptions{})
-	if err != nil {
-		logrus.Errorf("update gateway certificate secret, update failure: %v", err)
-		return err
-	}
-	hosts, err := apiutil.GetCertificateDomains(secret)
+
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		var rollbackErr error
+		if secretCreated {
+			rollbackErr = secrets.Delete(ctx, req.Name, metav1.DeleteOptions{})
+			if k8serror.IsNotFound(rollbackErr) {
+				rollbackErr = nil
+			}
+		} else {
+			previousSecret.ResourceVersion = persistedSecret.ResourceVersion
+			_, rollbackErr = secrets.Update(ctx, previousSecret, metav1.UpdateOptions{})
+		}
+		if rollbackErr != nil {
+			logrus.Errorf("rollback gateway certificate secret failure: %v", rollbackErr)
+			retErr = fmt.Errorf("%w; rollback gateway certificate secret: %v", retErr, rollbackErr)
+		}
+	}()
+
+	hosts, err := apiutil.GetCertificateDomains(persistedSecret)
 	if err != nil {
 		logrus.Errorf("get certificate domains failure: %v", err)
 		return err
 	}
-
-	// Check for domain conflicts across all namespaces
-	if err := apiutil.CheckDomainConflict(context.Background(), hosts, req.Namespace, req.Name); err != nil {
+	domainConflictChecker := g.domainConflictChecker
+	if domainConflictChecker == nil {
+		domainConflictChecker = apiutil.CheckDomainConflict
+	}
+	if err := domainConflictChecker(ctx, hosts, req.Namespace, req.Name); err != nil {
 		logrus.Errorf("domain conflict detected: %s", err.Error())
 		return err
 	}
 
-	oldApisixTls, err := g.apisixClient.ApisixV2().ApisixTlses(req.Namespace).Get(context.Background(), req.Name, metav1.GetOptions{})
-	if err != nil {
-		if k8serror.IsNotFound(err) {
-			_, err = g.apisixClient.ApisixV2().ApisixTlses(req.Namespace).Create(context.Background(), &v2.ApisixTls{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       apiutil.ApisixTLS,
-					APIVersion: apiutil.APIVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      req.Name,
-					Namespace: req.Namespace,
-				},
-				Spec: &v2.ApisixTlsSpec{
-					IngressClassName: "apisix",
-					Hosts:            hosts,
-					Secret: v2.ApisixSecret{
-						Name:      req.Name,
-						Namespace: req.Namespace,
-					},
-				},
-			}, metav1.CreateOptions{})
-			if err != nil {
-				logrus.Errorf("update gateway certificate apisix tls, add failure: %v", err)
-				return err
-			}
-			return nil
-		}
-		logrus.Errorf("update gateway certificate apisix tls, get failure: %v", err)
-		return err
+	desiredSpec := &v2.ApisixTlsSpec{
+		IngressClassName: "apisix",
+		Hosts:            hosts,
+		Secret: v2.ApisixSecret{
+			Name:      req.Name,
+			Namespace: req.Namespace,
+		},
 	}
-	oldApisixTls.Spec.Hosts = hosts
-	_, err = g.apisixClient.ApisixV2().ApisixTlses(req.Namespace).Update(context.Background(), oldApisixTls, metav1.UpdateOptions{})
-	if err != nil {
+	apisixTlses := g.apisixClient.ApisixV2().ApisixTlses(req.Namespace)
+	apisixTls, err := apisixTlses.Get(ctx, req.Name, metav1.GetOptions{})
+	switch {
+	case k8serror.IsNotFound(err):
+		_, err = apisixTlses.Create(ctx, &v2.ApisixTls{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       apiutil.ApisixTLS,
+				APIVersion: apiutil.APIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      req.Name,
+				Namespace: req.Namespace,
+			},
+			Spec: desiredSpec,
+		}, metav1.CreateOptions{})
+		if err != nil {
+			logrus.Errorf("create gateway certificate apisix tls failure: %v", err)
+			return err
+		}
+	case err != nil:
+		logrus.Errorf("get gateway certificate apisix tls failure: %v", err)
 		return err
+	default:
+		if apisixTls.Spec == nil {
+			apisixTls.Spec = desiredSpec
+		} else {
+			apisixTls.Spec.IngressClassName = desiredSpec.IngressClassName
+			apisixTls.Spec.Hosts = desiredSpec.Hosts
+			apisixTls.Spec.Secret = desiredSpec.Secret
+		}
+		if _, err = apisixTlses.Update(ctx, apisixTls, metav1.UpdateOptions{}); err != nil {
+			logrus.Errorf("update gateway certificate apisix tls failure: %v", err)
+			return err
+		}
 	}
 	return nil
 }
 
 // DeleteGatewayCertificate delete gateway certificate
 func (g *GatewayAction) DeleteGatewayCertificate(name, namespace string) error {
-	err := g.kubeClient.CoreV1().Secrets(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
-	if err != nil && !k8serror.IsNotFound(err) {
-		logrus.Errorf("delete gateway certificate secret failure: %v", err)
-		return err
-	}
-	err = g.apisixClient.ApisixV2().ApisixTlses(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err := g.apisixClient.ApisixV2().ApisixTlses(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil && !k8serror.IsNotFound(err) {
 		logrus.Errorf("delete gateway certificate apisix tls failure: %v", err)
+		return err
+	}
+	err = g.kubeClient.CoreV1().Secrets(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		logrus.Errorf("delete gateway certificate secret failure: %v", err)
 		return err
 	}
 	return nil

--- a/api/handler/gateway_action_test.go
+++ b/api/handler/gateway_action_test.go
@@ -1,13 +1,29 @@
 package handler
 
 import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"os"
+	"reflect"
 	"testing"
 
+	v2 "github.com/apache/apisix-ingress-controller/pkg/kube/apisix/apis/config/v2"
+	apisixversioned "github.com/apache/apisix-ingress-controller/pkg/kube/apisix/client/clientset/versioned"
+	apisixfake "github.com/apache/apisix-ingress-controller/pkg/kube/apisix/client/clientset/versioned/fake"
 	apimodel "github.com/goodrain/rainbond/api/model"
 	"github.com/goodrain/rainbond/db"
 	dbdao "github.com/goodrain/rainbond/db/dao"
 	dbmodel "github.com/goodrain/rainbond/db/model"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -170,6 +186,248 @@ func TestGatewayParentRefValuesReturnsFirstParentRef(t *testing.T) {
 	if sectionName != "https" {
 		t.Fatalf("sectionName = %q, expected https", sectionName)
 	}
+}
+
+func gatewayCertificateRequestForTest(t *testing.T, name, namespace, domain string) *apimodel.GatewayCertificate {
+	t.Helper()
+
+	cert, key, err := generateSelfSignedCertificate(domain)
+	if err != nil {
+		t.Fatalf("generate certificate: %v", err)
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal certificate key: %v", err)
+	}
+
+	return &apimodel.GatewayCertificate{
+		Name:        name,
+		Namespace:   namespace,
+		Certificate: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})),
+		PrivateKey:  string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})),
+	}
+}
+
+func gatewayActionForCertificateTest(kubeClient kubernetes.Interface, apisixClient apisixversioned.Interface) *GatewayAction {
+	return &GatewayAction{
+		kubeClient:   kubeClient,
+		apisixClient: apisixClient,
+		domainConflictChecker: func(context.Context, []v2.HostType, string, string) error {
+			return nil
+		},
+	}
+}
+
+func assertGatewayCertificateResources(t *testing.T, action *GatewayAction, req *apimodel.GatewayCertificate, domain string) {
+	t.Helper()
+
+	secret, err := action.kubeClient.CoreV1().Secrets(req.Namespace).Get(context.Background(), req.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reconciled Secret: %v", err)
+	}
+	if !bytes.Equal(secret.Data[corev1.TLSCertKey], []byte(req.Certificate)) {
+		t.Fatal("reconciled Secret certificate does not match request")
+	}
+	if !bytes.Equal(secret.Data[corev1.TLSPrivateKeyKey], []byte(req.PrivateKey)) {
+		t.Fatal("reconciled Secret private key does not match request")
+	}
+
+	tls, err := action.apisixClient.ApisixV2().ApisixTlses(req.Namespace).Get(context.Background(), req.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reconciled ApisixTls: %v", err)
+	}
+	if tls.Spec == nil {
+		t.Fatal("reconciled ApisixTls has no spec")
+	}
+	if tls.Spec.IngressClassName != "apisix" {
+		t.Fatalf("ingress class = %q, expected apisix", tls.Spec.IngressClassName)
+	}
+	if !reflect.DeepEqual(tls.Spec.Hosts, []v2.HostType{v2.HostType(domain)}) {
+		t.Fatalf("hosts = %#v, expected %q", tls.Spec.Hosts, domain)
+	}
+	if tls.Spec.Secret.Name != req.Name || tls.Spec.Secret.Namespace != req.Namespace {
+		t.Fatalf("secret reference = %s/%s, expected %s/%s", tls.Spec.Secret.Namespace, tls.Spec.Secret.Name, req.Namespace, req.Name)
+	}
+}
+
+// capability_id: rainbond.gateway.certificate-resource-consistency
+func TestGatewayCertificateResourceConsistency(t *testing.T) {
+	const (
+		name      = "gateway-cert"
+		namespace = "tenant-ns"
+	)
+
+	t.Run("add creates Secret and ApisixTls", func(t *testing.T) {
+		req := gatewayCertificateRequestForTest(t, name, namespace, "add.example.com")
+		action := gatewayActionForCertificateTest(k8sfake.NewSimpleClientset(), apisixfake.NewSimpleClientset())
+
+		if err := action.AddGatewayCertificate(req); err != nil {
+			t.Fatalf("add gateway certificate: %v", err)
+		}
+
+		assertGatewayCertificateResources(t, action, req, "add.example.com")
+	})
+
+	t.Run("add repairs an orphan Secret", func(t *testing.T) {
+		req := gatewayCertificateRequestForTest(t, name, namespace, "repaired.example.com")
+		existing := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       namespace,
+				ResourceVersion: "7",
+				Labels:          map[string]string{"keep": "label"},
+			},
+			Data: map[string][]byte{
+				corev1.TLSCertKey:       []byte("old certificate"),
+				corev1.TLSPrivateKeyKey: []byte("old private key"),
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+		action := gatewayActionForCertificateTest(k8sfake.NewSimpleClientset(existing), apisixfake.NewSimpleClientset())
+
+		if err := action.AddGatewayCertificate(req); err != nil {
+			t.Fatalf("repair gateway certificate: %v", err)
+		}
+
+		assertGatewayCertificateResources(t, action, req, "repaired.example.com")
+		secret, err := action.kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get repaired Secret: %v", err)
+		}
+		if secret.Labels["keep"] != "label" {
+			t.Fatalf("existing Secret metadata was not retained: %#v", secret.Labels)
+		}
+	})
+
+	t.Run("new Secret is removed after ApisixTls failure", func(t *testing.T) {
+		req := gatewayCertificateRequestForTest(t, name, namespace, "new-rollback.example.com")
+		kubeClient := k8sfake.NewSimpleClientset()
+		apisixClient := apisixfake.NewSimpleClientset()
+		apisixClient.PrependReactor("create", "apisixtlses", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("apisix create failed")
+		})
+		action := gatewayActionForCertificateTest(kubeClient, apisixClient)
+
+		if err := action.AddGatewayCertificate(req); err == nil {
+			t.Fatal("expected add to fail")
+		}
+
+		_, err := kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if !k8serrors.IsNotFound(err) {
+			t.Fatalf("new Secret was not rolled back, get error: %v", err)
+		}
+	})
+
+	t.Run("updated Secret is restored after ApisixTls failure", func(t *testing.T) {
+		req := gatewayCertificateRequestForTest(t, name, namespace, "updated-rollback.example.com")
+		existing := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       namespace,
+				ResourceVersion: "9",
+				Annotations:     map[string]string{"keep": "annotation"},
+			},
+			Data: map[string][]byte{
+				corev1.TLSCertKey:       []byte("original certificate"),
+				corev1.TLSPrivateKeyKey: []byte("original private key"),
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+		kubeClient := k8sfake.NewSimpleClientset(existing)
+		apisixClient := apisixfake.NewSimpleClientset()
+		apisixClient.PrependReactor("create", "apisixtlses", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("apisix create failed")
+		})
+		action := gatewayActionForCertificateTest(kubeClient, apisixClient)
+
+		if err := action.UpdateGatewayCertificate(req); err == nil {
+			t.Fatal("expected update to fail")
+		}
+
+		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get restored Secret: %v", err)
+		}
+		if !reflect.DeepEqual(secret.Data, existing.Data) {
+			t.Fatalf("restored Secret data = %#v, expected %#v", secret.Data, existing.Data)
+		}
+		if !reflect.DeepEqual(secret.Annotations, existing.Annotations) {
+			t.Fatalf("restored Secret annotations = %#v, expected %#v", secret.Annotations, existing.Annotations)
+		}
+	})
+
+	t.Run("update creates both resources when absent", func(t *testing.T) {
+		req := gatewayCertificateRequestForTest(t, name, namespace, "update.example.com")
+		action := gatewayActionForCertificateTest(k8sfake.NewSimpleClientset(), apisixfake.NewSimpleClientset())
+
+		if err := action.UpdateGatewayCertificate(req); err != nil {
+			t.Fatalf("update missing gateway certificate: %v", err)
+		}
+
+		assertGatewayCertificateResources(t, action, req, "update.example.com")
+	})
+
+	t.Run("update preserves existing mutual TLS client config", func(t *testing.T) {
+		req := gatewayCertificateRequestForTest(t, name, namespace, "mtls.example.com")
+		existingTLS := &v2.ApisixTls{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: &v2.ApisixTlsSpec{
+				Client: &v2.ApisixMutualTlsClientConfig{
+					CASecret: v2.ApisixSecret{Name: "client-ca", Namespace: namespace},
+					Depth:    2,
+				},
+			},
+		}
+		action := gatewayActionForCertificateTest(
+			k8sfake.NewSimpleClientset(),
+			apisixfake.NewSimpleClientset(existingTLS),
+		)
+
+		if err := action.UpdateGatewayCertificate(req); err != nil {
+			t.Fatalf("update gateway certificate: %v", err)
+		}
+
+		updatedTLS, err := action.apisixClient.ApisixV2().ApisixTlses(namespace).Get(
+			context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get updated ApisixTls: %v", err)
+		}
+		if !reflect.DeepEqual(updatedTLS.Spec.Client, existingTLS.Spec.Client) {
+			t.Fatalf("mutual TLS client config = %#v, expected %#v", updatedTLS.Spec.Client, existingTLS.Spec.Client)
+		}
+	})
+
+	t.Run("delete ignores missing resources", func(t *testing.T) {
+		action := gatewayActionForCertificateTest(k8sfake.NewSimpleClientset(), apisixfake.NewSimpleClientset())
+
+		if err := action.DeleteGatewayCertificate(name, namespace); err != nil {
+			t.Fatalf("delete missing gateway certificate: %v", err)
+		}
+	})
+
+	t.Run("delete removes ApisixTls before Secret", func(t *testing.T) {
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+		tls := &v2.ApisixTls{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+		kubeClient := k8sfake.NewSimpleClientset(secret)
+		apisixClient := apisixfake.NewSimpleClientset(tls)
+		var deletionOrder []string
+		apisixClient.PrependReactor("delete", "apisixtlses", func(k8stesting.Action) (bool, runtime.Object, error) {
+			deletionOrder = append(deletionOrder, "ApisixTls")
+			return false, nil, nil
+		})
+		kubeClient.PrependReactor("delete", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+			deletionOrder = append(deletionOrder, "Secret")
+			return false, nil, nil
+		})
+		action := gatewayActionForCertificateTest(kubeClient, apisixClient)
+
+		if err := action.DeleteGatewayCertificate(name, namespace); err != nil {
+			t.Fatalf("delete gateway certificate: %v", err)
+		}
+		if !reflect.DeepEqual(deletionOrder, []string{"ApisixTls", "Secret"}) {
+			t.Fatalf("deletion order = %#v, expected ApisixTls then Secret", deletionOrder)
+		}
+	})
 }
 
 // capability_id: rainbond.gateway.http-route-delete-component-event

--- a/api/handler/gateway_handler.go
+++ b/api/handler/gateway_handler.go
@@ -80,7 +80,7 @@ type GatewayHandler interface {
 // APIGatewayHandler api gateway handler
 type APIGatewayHandler interface {
 	// Don't imitate me for lazy writing
-	GetClient() *apisixversioned.Clientset
+	GetClient() apisixversioned.Interface
 	GetK8sClient() kubernetes.Interface
 	CreateCert(namespace, domain string) error
 }

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -2432,6 +2432,24 @@
       "status": "active"
     },
     {
+      "id": "rainbond.gateway.certificate-resource-consistency",
+      "title": "Keep gateway certificate resources consistent",
+      "title_zh": "Keep gateway certificate resources consistent",
+      "interface_type": "handler_method",
+      "interface": "api/handler.GatewayAction.AddGatewayCertificate",
+      "code_paths": [
+        "api/handler/gateway_action.go"
+      ],
+      "tests": [
+        {
+          "path": "api/handler/gateway_action_test.go",
+          "selector": "TestGatewayCertificateResourceConsistency"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "rainbond.gateway.http-route-delete-component-event",
       "title": "Record component event when deleting Gateway HTTPRoute",
       "title_zh": "\u5220\u9664\u7f51\u5173 HTTPRoute \u65f6\u8bb0\u5f55\u7ec4\u4ef6\u4e8b\u4ef6",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -136,6 +136,7 @@
 | rainbond.framework-detect.version-normalization | 规范化框架依赖版本号 | active | regression | builder/parser/code.cleanVersion | builder/parser/code/framework_test.go::TestCleanVersion |
 | rainbond.framework-detect.vite | 识别 Vite 框架 | active | regression | builder/parser/code.DetectFramework | builder/parser/code/framework_test.go::TestDetectFramework_Vite |
 | rainbond.gateway.allocate-lb-port | 分配可用网关负载均衡端口 | active | regression | api/handler.selectAvailablePort | api/handler/gateway_action_test.go::TestSelectAvailablePort |
+| rainbond.gateway.certificate-resource-consistency | Keep gateway certificate resources consistent | active | regression | api/handler.GatewayAction.AddGatewayCertificate | api/handler/gateway_action_test.go::TestGatewayCertificateResourceConsistency |
 | rainbond.gateway.http-route-delete-component-event | 删除网关 HTTPRoute 时记录组件事件 | active | regression | github.com/goodrain/rainbond/api/handler.(*GatewayAction).DeleteGatewayHTTPRoute | api/handler/gateway_action_test.go::TestCreateGatewayHTTPRouteDeleteEvents |
 | rainbond.gateway.reassign-conflicting-imported-tcp-port | Reassign imported TCP ports that conflict with existing NodePorts | active | regression | api/handler.reassignConflictingTCPRulePorts | api/handler/gateway_action_test.go::TestReassignConflictingTCPRulePorts |
 | rainbond.gateway.reject-duplicate-tcp-nodeport | Reject duplicate TCP NodePort bindings | active | regression | TCP NodePort binding | db/mysql/dao/gateway_test.go::TestTCPRuleDaoAddModelRejectsPortOwnedByAnotherRule<br>api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService |
@@ -1778,6 +1779,16 @@
 - 业务入口: `api/handler.selectAvailablePort`
 - 代码路径: `api/handler/gateway_action.go`
 - 测试路径: `api/handler/gateway_action_test.go::TestSelectAvailablePort`
+
+### Keep gateway certificate resources consistent
+
+- Capability ID: `rainbond.gateway.certificate-resource-consistency`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `handler_method`
+- 业务入口: `api/handler.GatewayAction.AddGatewayCertificate`
+- 代码路径: `api/handler/gateway_action.go`
+- 测试路径: `api/handler/gateway_action_test.go::TestGatewayCertificateResourceConsistency`
 
 ### 删除网关 HTTPRoute 时记录组件事件
 


### PR DESCRIPTION
## Summary

- Reconcile the Kubernetes TLS Secret and ApisixTls resource in the same add/update operation.
- Roll back Secret changes when certificate parsing, domain validation, or APISIX persistence fails.
- Make deletion idempotent and preserve existing mutual TLS client configuration.

## Testing

- go test ./api/handler -run GatewayCertificate -count=1
- go build ./...
- go vet ./...
- make check

## Related PRs

- https://github.com/goodrain/rainbond/pull/2666
- https://github.com/goodrain/rainbond-console/pull/2084
- https://github.com/goodrain/rainbond-ui/pull/1892