### PR TITLE
fix: export NPM_CONFIG_REGISTRY so global npm installs honour the mirror

### DIFF
--- a/builder/build/cnb/cnb_test.go
+++ b/builder/build/cnb/cnb_test.go
@@ -225,6 +225,137 @@ func TestInjectConfigFile(t *testing.T) {
 	})
 }
 
+// capability_id: rainbond.cnb.npmrc-registry-parse
+func TestNpmRegistryFromNpmrc(t *testing.T) {
+	tests := []struct{ name, content, want string }{
+		{"simple", "registry=https://registry.npmmirror.com\n", "https://registry.npmmirror.com"},
+		{"no trailing newline", "registry=https://registry.npmmirror.com", "https://registry.npmmirror.com"},
+		{"surrounding space", "  registry = https://registry.npmmirror.com  \n", "https://registry.npmmirror.com"},
+		{"quoted", `registry="https://registry.npmmirror.com"`, "https://registry.npmmirror.com"},
+		{"among other keys", "shamefully-hoist=true\nregistry=https://nexus.internal/repo\nstrict-peer-dependencies=false\n", "https://nexus.internal/repo"},
+		{"comments skipped", "# registry=https://wrong.example\n; registry=https://wrong.example\nregistry=https://right.example\n", "https://right.example"},
+		{"scoped only", "@myorg:registry=https://nexus.internal/repo\n", ""},
+		{"no registry key", "shamefully-hoist=true\n", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := npmRegistryFromNpmrc(tt.content); got != tt.want {
+				t.Errorf("npmRegistryFromNpmrc(%q) = %q; want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// capability_id: rainbond.cnb.npm-global-registry
+func TestResolveNpmRegistry(t *testing.T) {
+	t.Setenv("ENABLE_CHINA_MIRROR", "true")
+
+	t.Run("project npmrc wins over platform default", func(t *testing.T) {
+		dir := newNodeDir(t)
+		os.WriteFile(filepath.Join(dir, ".npmrc"), []byte("registry=https://nexus.internal/repo\n"), 0644)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{"CNB_MIRROR_SOURCE": "project"}}
+		if got := resolveNpmRegistry(re); got != "https://nexus.internal/repo" {
+			t.Errorf("got %q; want the project registry", got)
+		}
+	})
+
+	t.Run("explicit env wins over project npmrc", func(t *testing.T) {
+		dir := newNodeDir(t)
+		os.WriteFile(filepath.Join(dir, ".npmrc"), []byte("registry=https://nexus.internal/repo\n"), 0644)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{"CNB_NPM_REGISTRY": "https://explicit.example"}}
+		if got := resolveNpmRegistry(re); got != "https://explicit.example" {
+			t.Errorf("got %q; want the explicit override", got)
+		}
+	})
+
+	t.Run("BP_NODE_PROJECT_PATH npmrc preferred over root", func(t *testing.T) {
+		dir := newNodeDir(t)
+		os.WriteFile(filepath.Join(dir, ".npmrc"), []byte("registry=https://root.example\n"), 0644)
+		sub := filepath.Join(dir, "frontend")
+		os.MkdirAll(sub, 0755)
+		os.WriteFile(filepath.Join(sub, ".npmrc"), []byte("registry=https://sub.example\n"), 0644)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{"BP_NODE_PROJECT_PATH": "frontend"}}
+		if got := resolveNpmRegistry(re); got != "https://sub.example" {
+			t.Errorf("got %q; want the subdirectory registry", got)
+		}
+	})
+
+	t.Run("falls back to CNB_MIRROR_NPMRC", func(t *testing.T) {
+		dir := newNodeDir(t)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{"CNB_MIRROR_NPMRC": "registry=https://custom.example\n"}}
+		if got := resolveNpmRegistry(re); got != "https://custom.example" {
+			t.Errorf("got %q; want the CNB_MIRROR_NPMRC registry", got)
+		}
+	})
+
+	t.Run("falls back to china mirror default", func(t *testing.T) {
+		dir := newNodeDir(t)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{}}
+		if got := resolveNpmRegistry(re); got != "https://registry.npmmirror.com" {
+			t.Errorf("got %q; want the default mirror", got)
+		}
+	})
+
+	t.Run("project npmrc without registry key falls through", func(t *testing.T) {
+		dir := newNodeDir(t)
+		os.WriteFile(filepath.Join(dir, ".npmrc"), []byte("shamefully-hoist=true\n"), 0644)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{}}
+		if got := resolveNpmRegistry(re); got != "https://registry.npmmirror.com" {
+			t.Errorf("got %q; want the default mirror", got)
+		}
+	})
+
+	t.Run("china mirror disabled yields nothing", func(t *testing.T) {
+		t.Setenv("ENABLE_CHINA_MIRROR", "false")
+		dir := newNodeDir(t)
+		re := &build.Request{SourceDir: dir, BuildEnvs: map[string]string{}}
+		if got := resolveNpmRegistry(re); got != "" {
+			t.Errorf("got %q; want empty", got)
+		}
+	})
+}
+
+// capability_id: rainbond.cnb.npm-global-registry
+// NPM_CONFIG_REGISTRY must reach the buildpack process: npm ignores the project
+// .npmrc during `npm install -g pnpm@...`, so the env var is the only lever.
+func TestNodejsNpmRegistryAnnotation(t *testing.T) {
+	t.Setenv("ENABLE_CHINA_MIRROR", "true")
+	dir := newNodeDir(t)
+	os.WriteFile(filepath.Join(dir, ".npmrc"), []byte("registry=https://registry.npmmirror.com\n"), 0644)
+
+	annotations := (&Builder{}).buildPlatformAnnotations(&build.Request{
+		SourceDir: dir,
+		BuildEnvs: map[string]string{"CNB_MIRROR_SOURCE": "project", "CNB_FRAMEWORK": "vite"},
+	})
+
+	if got := annotations["cnb-npm-config-registry"]; got != "https://registry.npmmirror.com" {
+		t.Fatalf("cnb-npm-config-registry = %q; want the project registry", got)
+	}
+	if got := annotationKeyToBPEnv("cnb-npm-config-registry"); got != "NPM_CONFIG_REGISTRY" {
+		t.Fatalf("annotation maps to env %q; want NPM_CONFIG_REGISTRY", got)
+	}
+
+	volume, _ := (&Builder{}).createPlatformVolume(annotations, nil)
+	if volume == nil {
+		t.Fatal("expected a platform volume")
+	}
+	var found bool
+	for _, source := range volume.VolumeSource.Projected.Sources {
+		if source.DownwardAPI == nil {
+			continue
+		}
+		for _, item := range source.DownwardAPI.Items {
+			if item.Path == "env/NPM_CONFIG_REGISTRY" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("platform volume missing env/NPM_CONFIG_REGISTRY")
+	}
+}
+
 // --- platform.go ---
 
 // capability_id: rainbond.cnb.annotation-key-encode

--- a/builder/build/cnb/lang_nodejs.go
+++ b/builder/build/cnb/lang_nodejs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/goodrain/rainbond/builder/build"
 	"github.com/goodrain/rainbond/util"
@@ -45,6 +46,10 @@ func (n *nodejsConfig) BuildAnnotations(re *build.Request, annotations map[strin
 	}
 
 	applyDependencyMirrorAnnotation(annotations)
+
+	// Registry for global npm tooling. The project .npmrc cannot cover this,
+	// see resolveNpmRegistry.
+	setAnnotationValue(annotations, "cnb-npm-config-registry", resolveNpmRegistry(re))
 
 	// Build script
 	if v, ok := re.BuildEnvs["CNB_BUILD_SCRIPT"]; ok && v != "" {
@@ -113,6 +118,78 @@ func (n *nodejsConfig) InjectMirrorConfig(re *build.Request) error {
 // CustomOrder returns nil — Node.js projects use the default builder order.
 func (n *nodejsConfig) CustomOrder(re *build.Request) []orderBuildpack {
 	return nil
+}
+
+// resolveNpmRegistry returns the registry npm should use for global installs.
+//
+// The pnpm buildpack bootstraps itself with `npm install -g pnpm@<version>`, and
+// npm deliberately ignores the per-project .npmrc in global mode. So the mirror
+// configured for the project — whether written by InjectMirrorConfig or committed
+// by the user — never applies to that bootstrap, which then falls back to
+// registry.npmjs.org. That fails on China networks and is unreachable in
+// air-gapped clusters, even though the project mirror itself is fine.
+//
+// Exporting NPM_CONFIG_REGISTRY closes the gap: environment variables are the one
+// config source npm still honours in global mode. This mirrors how Go builds
+// receive GOPROXY (see lang_golang.go).
+//
+// Priority: CNB_NPM_REGISTRY > project .npmrc > CNB_MIRROR_NPMRC > China mirror default.
+// The project .npmrc is preferred over any platform default because npm ranks
+// environment variables *above* the project .npmrc: a value that disagreed with the
+// project would silently redirect the whole install, not just the bootstrap.
+func resolveNpmRegistry(re *build.Request) string {
+	if registry := firstNonEmptyEnv(re.BuildEnvs, "CNB_NPM_REGISTRY", "BUILD_NPM_REGISTRY"); registry != "" {
+		return strings.TrimSpace(registry)
+	}
+	if registry := npmRegistryFromNpmrc(readProjectNpmrc(re)); registry != "" {
+		return registry
+	}
+	if registry := npmRegistryFromNpmrc(re.BuildEnvs["CNB_MIRROR_NPMRC"]); registry != "" {
+		return registry
+	}
+	if util.GetenvDefault("ENABLE_CHINA_MIRROR", "true") != "true" {
+		return ""
+	}
+	return npmRegistryFromNpmrc(util.GetenvDefault("DEFAULT_NPMRC", DefaultNpmrcContent))
+}
+
+// readProjectNpmrc reads the .npmrc that the Node.js buildpacks will see.
+// BP_NODE_PROJECT_PATH moves the project root into a subdirectory, so look
+// there first and fall back to the source root.
+func readProjectNpmrc(re *build.Request) string {
+	if re.SourceDir == "" {
+		return ""
+	}
+	dirs := make([]string, 0, 2)
+	if sub := strings.TrimSpace(re.BuildEnvs["BP_NODE_PROJECT_PATH"]); sub != "" {
+		dirs = append(dirs, filepath.Join(re.SourceDir, sub))
+	}
+	dirs = append(dirs, re.SourceDir)
+
+	for _, dir := range dirs {
+		if data, err := os.ReadFile(filepath.Join(dir, ".npmrc")); err == nil {
+			return string(data)
+		}
+	}
+	return ""
+}
+
+// npmRegistryFromNpmrc extracts the default `registry=` value from .npmrc content.
+// Scoped entries (`@scope:registry=`) are ignored: they do not apply to the
+// unscoped packages installed during bootstrap.
+func npmRegistryFromNpmrc(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "registry" {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"'`)
+	}
+	return ""
 }
 
 // injectConfigFile injects a single config file (.npmrc or .yarnrc).

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -1160,6 +1160,47 @@
       "status": "active"
     },
     {
+      "id": "rainbond.cnb.npm-global-registry",
+      "title": "Export NPM_CONFIG_REGISTRY for global npm installs",
+      "title_zh": "\u4e3a\u5168\u5c40 npm \u5b89\u88c5\u5bfc\u51fa NPM_CONFIG_REGISTRY",
+      "interface_type": "workflow",
+      "interface": "builder/build/cnb.resolveNpmRegistry",
+      "code_paths": [
+        "builder/build/cnb/lang_nodejs.go",
+        "builder/build/cnb/platform.go"
+      ],
+      "tests": [
+        {
+          "path": "builder/build/cnb/cnb_test.go",
+          "selector": "TestResolveNpmRegistry"
+        },
+        {
+          "path": "builder/build/cnb/cnb_test.go",
+          "selector": "TestNodejsNpmRegistryAnnotation"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.cnb.npmrc-registry-parse",
+      "title": "Parse default registry key from .npmrc content",
+      "title_zh": "\u4ece .npmrc \u5185\u5bb9\u4e2d\u89e3\u6790\u9ed8\u8ba4 registry \u914d\u7f6e\u9879",
+      "interface_type": "package_function",
+      "interface": "builder/build/cnb.npmRegistryFromNpmrc",
+      "code_paths": [
+        "builder/build/cnb/lang_nodejs.go"
+      ],
+      "tests": [
+        {
+          "path": "builder/build/cnb/cnb_test.go",
+          "selector": "TestNpmRegistryFromNpmrc"
+        }
+      ],
+      "test_type": "unit",
+      "status": "active"
+    },
+    {
       "id": "rainbond.cnb.offline-mode",
       "title": "Resolve offline mode CNB image behavior",
       "title_zh": "\u89e3\u6790\u79bb\u7ebf\u6a21\u5f0f\u4e0b\u7684 CNB \u955c\u50cf\u884c\u4e3a",


### PR DESCRIPTION
## Problem

pnpm-based Node.js projects fail to build whenever `registry.npmjs.org` is slow or unreachable, **even when the project has a correctly configured mirror**:

```
Rainbond Buildpack for PNPM Install 2.3.3
Running 'npm install -g pnpm@latest'
npm error 503 Service Unavailable - GET https://registry.npmjs.org/pnpm
npm error code E503
CNB build job failed
```

The project in question had a committed `.npmrc` containing exactly `registry=https://registry.npmmirror.com`, and the component was configured with Mirror source = *use project config*. Everything on the user's side was correct.

## Root cause

The pnpm buildpack bootstraps itself with `npm install -g pnpm@<version>`, and [npm deliberately ignores the per-project `.npmrc` in global mode](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc):

> Additionally, this file is not read in global mode, such as when running `npm install -g`.

So neither the `.npmrc` written by `InjectMirrorConfig` nor one committed by the user can ever influence that bootstrap — it always falls back to `registry.npmjs.org`.

Two consequences:

- On China networks this is flaky (the 503 above), and it is **not** transient in nature — every cache-cold build depends on `registry.npmjs.org` being reachable.
- In air-gapped clusters pnpm projects simply cannot build, despite `BP_DEPENDENCY_MIRROR` / offline builder images being configured. Note in the log above that Node Engine 18.20.8 downloads fine via the dependency mirror; only the npm bootstrap escapes it.

In global mode npm honours just four config sources: CLI flags, **environment variables**, `~/.npmrc`, and `$PREFIX/etc/npmrc`. Rainbond currently sets none of them.

## Fix

Resolve a registry and export it as `NPM_CONFIG_REGISTRY` through the existing platform-annotation channel (`cnb-npm-config-registry` → downward API → `/platform/env/NPM_CONFIG_REGISTRY` → lifecycle → buildpack process env). This is the same mechanism that already delivers `GOPROXY` for Go builds and `BP_NODE_VERSION` for Node builds.

Resolution priority:

1. `CNB_NPM_REGISTRY` / `BUILD_NPM_REGISTRY` — explicit override
2. the project's `.npmrc` (`BP_NODE_PROJECT_PATH` subdirectory first, then source root)
3. `CNB_MIRROR_NPMRC`
4. the China mirror default, when `ENABLE_CHINA_MIRROR` is enabled

**The project `.npmrc` deliberately outranks any platform default.** npm ranks environment variables *above* the project `.npmrc`, so an injected value that disagreed with the project would silently redirect the entire install rather than just the bootstrap — breaking users who point at a private registry. Reading the value back out of the project file keeps the two in sync.

Only the default `registry=` key is extracted; `@scope:registry=` entries are ignored, since they do not apply to the unscoped `pnpm` package and remain effective through the project `.npmrc` during the non-global phases.

When `ENABLE_CHINA_MIRROR=false` and the project configures nothing, the resolver returns empty and `setAnnotationValue` skips the annotation — behaviour is unchanged from before this patch.

## Verification

The delivery channel is already proven in production: the same failing build log shows `BP_NODE_VERSION -> "18.20.8"` being picked up by node-engine, which reaches the buildpack via this exact annotation → `/platform/env` path.

On the buildpack side, `packit`'s `pexec` leaves `cmd.Env` unset when `Execution.Env` is nil (`if len(execution.Env) > 0 { cmd.Env = execution.Env }`), so the `npm install -g` subprocess inherits the buildpack process environment. Confirmed against `goodrain/pnpm-install` v2.3.3, the version in the failing log.

Tests added in `cnb_test.go` cover `.npmrc` parsing, the resolution priority chain, `BP_NODE_PROJECT_PATH` subdirectories, and an end-to-end assertion that reproduces the reported configuration (project `.npmrc` + `CNB_MIRROR_SOURCE=project` + Vite) and checks that `env/NPM_CONFIG_REGISTRY` actually lands in the platform volume.

```
ok  github.com/goodrain/rainbond/builder/build/cnb    0.798s
ok  github.com/goodrain/rainbond/builder/parser       3.201s
ok  github.com/goodrain/rainbond/builder/parser/code  0.396s
```

## Known gap (not addressed here)

`NPM_CONFIG_REGISTRY` can only set the default registry address — it cannot carry credentials such as `//registry.internal/:_authToken=`. Bootstrapping from an authenticated private registry would additionally require `NPM_CONFIG_GLOBALCONFIG` or a user-level `.npmrc`.

Relatedly, `goodrain/pnpm-install` computes `globalNpmrcPath` from the platform bindings but never passes it to the `npm install -g` execution. Fixing that upstream is worthwhile, but it is currently a no-op for Rainbond: `resolvePlatformBindings` only creates `maven` and `nugetconfig` bindings, so no `npmrc` binding is ever produced. That change is therefore not a prerequisite for this fix.
