### PR TITLE
fix: restore pod memory metric fallback

### DIFF
--- a/api/handler/resource_query_scope_test.go
+++ b/api/handler/resource_query_scope_test.go
@@ -211,7 +211,12 @@ func TestPopulatePodContainerMemoryUsesOneNamespaceScopedExactQuery(t *testing.T
 }
 
 func TestPopulatePodContainerMemoryUsesEqualityMatcherForOnePod(t *testing.T) {
-	prom := &recordingPrometheus{}
+	prom := &recordingPrometheus{metric: func(string) promcli.Metric {
+		return vectorMetric(metricValue(map[string]string{
+			"pod":       "component-a.0",
+			"container": "main",
+		}, 128))
+	}}
 	action := &ServiceAction{prometheusCli: prom}
 	pods := []*K8sPodInfo{
 		{PodName: "component-a.0", Container: map[string]map[string]string{"main": {"memory_usage": "0"}}},
@@ -221,6 +226,42 @@ func TestPopulatePodContainerMemoryUsesEqualityMatcherForOnePod(t *testing.T) {
 
 	require.Len(t, prom.queries, 1)
 	assert.Equal(t, `max(container_memory_rss{namespace="tenant-ns",pod="component-a.0"}) by (pod,container)`, prom.queries[0])
+}
+
+func TestPopulatePodContainerMemoryFallsBackWhenNamespaceDoesNotMatchMetrics(t *testing.T) {
+	prom := &recordingPrometheus{metric: func(expr string) promcli.Metric {
+		if strings.Contains(expr, `namespace="stale-namespace"`) {
+			return promcli.Metric{}
+		}
+		return vectorMetric(metricValue(map[string]string{
+			"pod":       "component-a.0",
+			"container": "main",
+		}, 256))
+	}}
+	action := &ServiceAction{prometheusCli: prom}
+	pods := []*K8sPodInfo{
+		{PodName: "component-a.0", Container: map[string]map[string]string{"main": {"memory_usage": "0"}}},
+	}
+
+	action.populatePodContainerMemory("stale-namespace", pods)
+
+	require.Len(t, prom.queries, 2)
+	assert.Equal(t, `max(container_memory_rss{namespace="stale-namespace",pod="component-a.0"}) by (pod,container)`, prom.queries[0])
+	assert.Equal(t, `max(container_memory_rss{pod="component-a.0"}) by (pod,container)`, prom.queries[1])
+	assert.Equal(t, "256", pods[0].Container["main"]["memory_usage"])
+}
+
+func TestGetPodContainerMemoryDoesNotRetryPrometheusErrors(t *testing.T) {
+	prom := &recordingPrometheus{metric: func(string) promcli.Metric {
+		return promcli.Metric{Error: "query timeout"}
+	}}
+	action := &ServiceAction{prometheusCli: prom}
+
+	usage, err := action.getPodContainerMemory("tenant-ns", []string{"component-a.0"})
+
+	assert.Empty(t, usage)
+	assert.EqualError(t, err, "query pod container memory: query timeout")
+	assert.Len(t, prom.queries, 1)
 }
 
 func TestPopulatePodContainerMemorySkipsPrometheusWithoutPods(t *testing.T) {

--- a/api/handler/service.go
+++ b/api/handler/service.go
@@ -3201,12 +3201,29 @@ func (s *ServiceAction) getPodContainerMemory(namespace string, podNames []strin
 		rawPodNames = append(rawPodNames, podName)
 	}
 	sort.Strings(rawPodNames)
-	labels := []string{buildExactPrometheusLabelMatcher("pod", rawPodNames)}
+	podMatcher := buildExactPrometheusLabelMatcher("pod", rawPodNames)
+	labels := []string{podMatcher}
 	if namespace != "" {
 		labels = append([]string{fmt.Sprintf(`namespace=%q`, namespace)}, labels...)
 	}
-	query := fmt.Sprintf(`max(container_memory_rss{%s}) by (pod,container)`, strings.Join(labels, ","))
-	metric := s.prometheusCli.GetMetric(query, time.Now())
+	queryMetric := func(queryLabels []string) (prometheus.Metric, error) {
+		query := fmt.Sprintf(`max(container_memory_rss{%s}) by (pod,container)`, strings.Join(queryLabels, ","))
+		metric := s.prometheusCli.GetMetric(query, time.Now())
+		if metric.Error != "" {
+			return metric, fmt.Errorf("query pod container memory: %s", metric.Error)
+		}
+		return metric, nil
+	}
+	metric, err := queryMetric(labels)
+	if err != nil {
+		return memoryUsageMap, err
+	}
+	if namespace != "" && len(metric.MetricData.MetricValues) == 0 {
+		metric, err = queryMetric([]string{podMatcher})
+		if err != nil {
+			return memoryUsageMap, err
+		}
+	}
 
 	for _, re := range metric.MetricData.MetricValues {
 		var containerName = re.Metadata["container"]
@@ -3233,7 +3250,11 @@ func (s *ServiceAction) populatePodContainerMemory(namespace string, pods []*K8s
 			podNames = append(podNames, pod.PodName)
 		}
 	}
-	containerMemInfo, _ := s.getPodContainerMemory(namespace, podNames)
+	containerMemInfo, err := s.getPodContainerMemory(namespace, podNames)
+	if err != nil {
+		logrus.Warnf("get pod container memory failed, namespace: %s, error: %v", namespace, err)
+		return
+	}
 	for _, pod := range pods {
 		if pod == nil {
 			continue


### PR DESCRIPTION
## Summary

- keep namespace-scoped exact Prometheus queries as the primary path
- retry with an exact pod-name query when stored namespace data does not match metric labels
- report Prometheus query failures instead of silently returning zero usage
- avoid fallback retries when Prometheus itself returns an error

## Verification

- GOFLAGS=-mod=mod go test ./api/handler -count=1
- GOFLAGS=-mod=mod go build ./...
- GOFLAGS=-mod=mod go vet ./...
- GOFLAGS=-mod=mod make check