### PR TITLE
fix: preserve service identity across component restarts

### DIFF
--- a/test-manifest.json
+++ b/test-manifest.json
@@ -3271,6 +3271,60 @@
       "status": "active"
     },
     {
+      "id": "rainbond.lifecycle.service-reconcile-preserves-identity",
+      "title": "Service reconciliation preserves allocated Kubernetes identity",
+      "title_zh": "Service reconciliation preserves allocated Kubernetes identity",
+      "interface_type": "package_function",
+      "interface": "worker/appm/controller.CreateKubeService",
+      "code_paths": [
+        "worker/appm/controller/kube-controller.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/controller/kube-controller_test.go",
+          "selector": "TestCreateKubeServiceReconcilesOwnedServiceAndPreservesIdentity"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.lifecycle.service-reconcile-rejects-foreign-owner",
+      "title": "Service reconciliation rejects foreign ownership",
+      "title_zh": "Service reconciliation rejects foreign ownership",
+      "interface_type": "package_function",
+      "interface": "worker/appm/controller.CreateKubeService",
+      "code_paths": [
+        "worker/appm/controller/kube-controller.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/controller/kube-controller_test.go",
+          "selector": "TestCreateKubeServiceRejectsForeignService"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.lifecycle.stop-preserves-service",
+      "title": "Stopping a component preserves its generated Service identity",
+      "title_zh": "Stopping a component preserves its generated Service identity",
+      "interface_type": "workflow",
+      "interface": "worker/appm/controller.stopController.stopOne",
+      "code_paths": [
+        "worker/appm/controller/stop.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/controller/stop_test.go",
+          "selector": "TestStopPreservesGeneratedService"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "rainbond.manual-pvc-upgrade-preserves-bound-claim-immutable-spec",
       "title": "Preserve bound manual PVC immutable spec fields during app upgrade",
       "interface_type": "workflow",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -181,6 +181,9 @@
 | rainbond.license.status-projection | 将许可证令牌投影为状态响应 | active | regression | api/util/license.TokenToStatus | api/util/license/rsa_license_test.go::TestTokenToStatus |
 | rainbond.license.validate-token | 校验许可证企业绑定与生效时间窗口 | active | regression | api/util/license.ValidateToken | api/util/license/rsa_license_test.go::TestValidateToken_Valid |
 | rainbond.license.verify-signature | 校验许可证 RSA 签名 | active | regression | api/util/license.VerifySignature | api/util/license/rsa_license_test.go::TestVerifySignature_Valid |
+| rainbond.lifecycle.service-reconcile-preserves-identity | Service reconciliation preserves allocated Kubernetes identity | active | regression | worker/appm/controller.CreateKubeService | worker/appm/controller/kube-controller_test.go::TestCreateKubeServiceReconcilesOwnedServiceAndPreservesIdentity |
+| rainbond.lifecycle.service-reconcile-rejects-foreign-owner | Service reconciliation rejects foreign ownership | active | regression | worker/appm/controller.CreateKubeService | worker/appm/controller/kube-controller_test.go::TestCreateKubeServiceRejectsForeignService |
+| rainbond.lifecycle.stop-preserves-service | Stopping a component preserves its generated Service identity | active | regression | worker/appm/controller.stopController.stopOne | worker/appm/controller/stop_test.go::TestStopPreservesGeneratedService |
 | rainbond.manual-pvc-upgrade-preserves-bound-claim-immutable-spec | Preserve bound manual PVC immutable spec fields during app upgrade | active | regression | worker/appm/controller.upgradeController.upgradeManualClaims | worker/appm/controller/upgrade_manual_claim_test.go::TestUpgradeControllerUpgradeManualClaimsPreservesBoundClaimImmutableSpec |
 | rainbond.manual-pvc-upgrade-preserves-existing-metadata | Preserve existing manual PVC metadata during app upgrade | active | regression | worker/appm/controller.upgradeController.upgradeManualClaims | worker/appm/controller/upgrade_manual_claim_test.go::TestUpgradeControllerUpgradeManualClaimsPreservesExistingMetadata |
 | rainbond.manual-pvc-upgrade-skips-unchanged-storage | Skip manual PVC updates when storage request is unchanged | active | regression | worker/appm/controller.upgradeController.upgradeManualClaims | worker/appm/controller/upgrade_manual_claim_test.go::TestUpgradeControllerUpgradeManualClaimsSkipsUnchangedStorage |
@@ -2233,6 +2236,36 @@
 - 业务入口: `api/util/license.VerifySignature`
 - 代码路径: `api/util/license/rsa_license.go`
 - 测试路径: `api/util/license/rsa_license_test.go::TestVerifySignature_Valid`
+
+### Service reconciliation preserves allocated Kubernetes identity
+
+- Capability ID: `rainbond.lifecycle.service-reconcile-preserves-identity`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `worker/appm/controller.CreateKubeService`
+- 代码路径: `worker/appm/controller/kube-controller.go`
+- 测试路径: `worker/appm/controller/kube-controller_test.go::TestCreateKubeServiceReconcilesOwnedServiceAndPreservesIdentity`
+
+### Service reconciliation rejects foreign ownership
+
+- Capability ID: `rainbond.lifecycle.service-reconcile-rejects-foreign-owner`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `worker/appm/controller.CreateKubeService`
+- 代码路径: `worker/appm/controller/kube-controller.go`
+- 测试路径: `worker/appm/controller/kube-controller_test.go::TestCreateKubeServiceRejectsForeignService`
+
+### Stopping a component preserves its generated Service identity
+
+- Capability ID: `rainbond.lifecycle.stop-preserves-service`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/controller.stopController.stopOne`
+- 代码路径: `worker/appm/controller/stop.go`
+- 测试路径: `worker/appm/controller/stop_test.go::TestStopPreservesGeneratedService`
 
 ### Preserve bound manual PVC immutable spec fields during app upgrade
 

--- a/worker/appm/controller/kube-controller.go
+++ b/worker/appm/controller/kube-controller.go
@@ -20,40 +20,136 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 )
 
-//CreateKubeService create kube service
+const serviceIDLabel = "service_id"
+
+// CreateKubeService creates missing Services and reconciles existing Rainbond-owned Services.
 func CreateKubeService(client kubernetes.Interface, namespace string, services ...*corev1.Service) error {
-	var retryService []*corev1.Service
-	for i := range services {
-		createService := services[i]
-		if _, err := client.CoreV1().Services(namespace).Create(context.Background(), createService, metav1.CreateOptions{}); err != nil {
-			// Ignore if the Service is invalid with this error message:
-			// 	Service "kube-dns" is invalid: spec.clusterIP: Invalid value: "10.96.0.10": provided IP is already allocated
-			if !errors.IsAlreadyExists(err) && !errors.IsInvalid(err) {
-				retryService = append(retryService, createService)
-				continue
-			}
-			if _, err := client.CoreV1().Services(namespace).Update(context.Background(), createService, metav1.UpdateOptions{}); err != nil {
-				retryService = append(retryService, createService)
-				continue
-			}
+	for _, desired := range services {
+		if desired == nil || desired.Name == "" {
+			return fmt.Errorf("service name is required")
 		}
-	}
-	//second attempt
-	for _, service := range retryService {
-		_, err := client.CoreV1().Services(namespace).Create(context.Background(), service, metav1.CreateOptions{})
-		if err != nil {
-			if errors.IsAlreadyExists(err) {
-				continue
-			}
-			return err
+		if desired.Labels[serviceIDLabel] == "" {
+			return fmt.Errorf("service %s/%s has no %q ownership label", namespace, desired.Name, serviceIDLabel)
+		}
+		if err := ensureKubeService(client, namespace, desired); err != nil {
+			return fmt.Errorf("ensure service %s/%s: %w", namespace, desired.Name, err)
 		}
 	}
 	return nil
+}
+
+func ensureKubeService(client kubernetes.Interface, namespace string, desired *corev1.Service) error {
+	ctx := context.Background()
+	return retry.OnError(retry.DefaultRetry, isRetryableServiceEnsureError, func() error {
+		existing, err := client.CoreV1().Services(namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			_, err = client.CoreV1().Services(namespace).Create(ctx, desired.DeepCopy(), metav1.CreateOptions{})
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		if err := validateServiceOwnership(existing, desired); err != nil {
+			return err
+		}
+		if err := validateClusterIPMode(existing, desired); err != nil {
+			return err
+		}
+
+		updated := reconciledService(existing, desired)
+		_, err = client.CoreV1().Services(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func isRetryableServiceEnsureError(err error) bool {
+	return errors.IsAlreadyExists(err) || errors.IsConflict(err) || errors.IsNotFound(err)
+}
+
+func validateServiceOwnership(existing, desired *corev1.Service) error {
+	desiredServiceID := desired.Labels[serviceIDLabel]
+	existingServiceID := existing.Labels[serviceIDLabel]
+	if desiredServiceID == "" {
+		return fmt.Errorf("desired service has no %q ownership label", serviceIDLabel)
+	}
+	if existingServiceID != desiredServiceID {
+		return fmt.Errorf("existing service belongs to service %q, expected %q", existingServiceID, desiredServiceID)
+	}
+	return nil
+}
+
+func validateClusterIPMode(existing, desired *corev1.Service) error {
+	existingHeadless := existing.Spec.ClusterIP == corev1.ClusterIPNone
+	desiredHeadless := desired.Spec.ClusterIP == corev1.ClusterIPNone
+	if existingHeadless != desiredHeadless {
+		return fmt.Errorf("cluster IP mode is immutable: existing=%q desired=%q", existing.Spec.ClusterIP, desired.Spec.ClusterIP)
+	}
+	return nil
+}
+
+func reconciledService(existing, desired *corev1.Service) *corev1.Service {
+	updated := existing.DeepCopy()
+	desiredCopy := desired.DeepCopy()
+
+	updated.Labels = mergeStringMap(existing.Labels, desired.Labels)
+	updated.Annotations = mergeStringMap(existing.Annotations, desired.Annotations)
+	updated.Spec = desiredCopy.Spec
+	updated.Spec.ClusterIP = existing.Spec.ClusterIP
+	updated.Spec.ClusterIPs = append([]string(nil), existing.Spec.ClusterIPs...)
+	updated.Spec.IPFamilies = append([]corev1.IPFamily(nil), existing.Spec.IPFamilies...)
+	if existing.Spec.IPFamilyPolicy != nil {
+		policy := *existing.Spec.IPFamilyPolicy
+		updated.Spec.IPFamilyPolicy = &policy
+	}
+	if updated.Spec.Type == corev1.ServiceTypeLoadBalancer && updated.Spec.HealthCheckNodePort == 0 {
+		updated.Spec.HealthCheckNodePort = existing.Spec.HealthCheckNodePort
+	}
+	if updated.Spec.Type == corev1.ServiceTypeNodePort || updated.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		preserveAllocatedNodePorts(updated.Spec.Ports, existing.Spec.Ports)
+	}
+	return updated
+}
+
+func mergeStringMap(existing, desired map[string]string) map[string]string {
+	merged := make(map[string]string, len(existing)+len(desired))
+	for key, value := range existing {
+		merged[key] = value
+	}
+	for key, value := range desired {
+		merged[key] = value
+	}
+	return merged
+}
+
+func preserveAllocatedNodePorts(desired, existing []corev1.ServicePort) {
+	for desiredIndex := range desired {
+		if desired[desiredIndex].NodePort != 0 {
+			continue
+		}
+		for existingIndex := range existing {
+			if servicePortsShareIdentity(desired[desiredIndex], existing[existingIndex]) {
+				desired[desiredIndex].NodePort = existing[existingIndex].NodePort
+				break
+			}
+		}
+	}
+}
+
+func servicePortsShareIdentity(desired, existing corev1.ServicePort) bool {
+	if desired.Protocol != existing.Protocol {
+		return false
+	}
+	if desired.Name != "" || existing.Name != "" {
+		return desired.Name == existing.Name
+	}
+	return desired.Port == existing.Port
 }

--- a/worker/appm/controller/kube-controller_test.go
+++ b/worker/appm/controller/kube-controller_test.go
@@ -1,0 +1,260 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func generatedService(name, serviceID string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"creator":    "Rainbond",
+				"service_id": serviceID,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{"name": "java"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http-8080",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+		},
+	}
+}
+
+func TestCreateKubeServiceCreatesMissingService(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	desired := generatedService("java", "service-1")
+
+	if err := CreateKubeService(client, desired.Namespace, desired); err != nil {
+		t.Fatalf("create service: %v", err)
+	}
+
+	got, err := client.CoreV1().Services(desired.Namespace).Get(context.Background(), desired.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get created service: %v", err)
+	}
+	if got.Labels["service_id"] != "service-1" {
+		t.Fatalf("expected managed service label, got %#v", got.Labels)
+	}
+}
+
+// capability_id: rainbond.lifecycle.service-reconcile-preserves-identity
+func TestCreateKubeServiceReconcilesOwnedServiceAndPreservesIdentity(t *testing.T) {
+	policy := corev1.IPFamilyPolicySingleStack
+	existing := generatedService("java", "service-1")
+	existing.UID = types.UID("service-uid")
+	existing.ResourceVersion = "7"
+	existing.Labels["external-label"] = "keep"
+	existing.Annotations = map[string]string{"cloud.example.com/allocated": "keep"}
+	existing.Spec.Type = corev1.ServiceTypeLoadBalancer
+	existing.Spec.ClusterIP = "10.0.0.8"
+	existing.Spec.ClusterIPs = []string{"10.0.0.8"}
+	existing.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+	existing.Spec.IPFamilyPolicy = &policy
+	existing.Spec.HealthCheckNodePort = 32001
+	existing.Spec.Ports[0].NodePort = 30080
+
+	desired := generatedService("java", "service-1")
+	desired.Labels["version"] = "v2"
+	desired.Annotations = map[string]string{"rainbond.com/tolerate-unready-endpoints": "true"}
+	desired.Spec.Type = corev1.ServiceTypeLoadBalancer
+	desired.Spec.Selector = map[string]string{"name": "java-v2"}
+	desired.Spec.Ports[0].Port = 8081
+	desired.Spec.Ports[0].TargetPort = intstr.FromInt(9090)
+
+	client := k8sfake.NewSimpleClientset(existing)
+	if err := CreateKubeService(client, desired.Namespace, desired); err != nil {
+		t.Fatalf("reconcile service: %v", err)
+	}
+
+	got, err := client.CoreV1().Services(desired.Namespace).Get(context.Background(), desired.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reconciled service: %v", err)
+	}
+	if got.UID != existing.UID || got.ResourceVersion != existing.ResourceVersion {
+		t.Fatalf("expected service identity to be preserved, got uid=%q resourceVersion=%q", got.UID, got.ResourceVersion)
+	}
+	if got.Spec.ClusterIP != existing.Spec.ClusterIP || len(got.Spec.ClusterIPs) != 1 || got.Spec.ClusterIPs[0] != existing.Spec.ClusterIPs[0] {
+		t.Fatalf("expected cluster IP allocation to be preserved, got clusterIP=%q clusterIPs=%v", got.Spec.ClusterIP, got.Spec.ClusterIPs)
+	}
+	if got.Spec.IPFamilyPolicy == nil || *got.Spec.IPFamilyPolicy != policy || len(got.Spec.IPFamilies) != 1 || got.Spec.IPFamilies[0] != corev1.IPv4Protocol {
+		t.Fatalf("expected IP family allocation to be preserved, got policy=%v families=%v", got.Spec.IPFamilyPolicy, got.Spec.IPFamilies)
+	}
+	if got.Spec.HealthCheckNodePort != existing.Spec.HealthCheckNodePort || got.Spec.Ports[0].NodePort != existing.Spec.Ports[0].NodePort {
+		t.Fatalf("expected node port allocations to be preserved, got health=%d nodePort=%d", got.Spec.HealthCheckNodePort, got.Spec.Ports[0].NodePort)
+	}
+	if got.Spec.Ports[0].Port != 8081 || got.Spec.Ports[0].TargetPort != intstr.FromInt(9090) {
+		t.Fatalf("expected desired port configuration, got %#v", got.Spec.Ports[0])
+	}
+	if got.Spec.Selector["name"] != "java-v2" || got.Labels["version"] != "v2" {
+		t.Fatalf("expected desired managed fields, got selector=%v labels=%v", got.Spec.Selector, got.Labels)
+	}
+	if got.Labels["external-label"] != "keep" || got.Annotations["cloud.example.com/allocated"] != "keep" {
+		t.Fatalf("expected external metadata to be preserved, got labels=%v annotations=%v", got.Labels, got.Annotations)
+	}
+	if got.Annotations["rainbond.com/tolerate-unready-endpoints"] != "true" {
+		t.Fatalf("expected desired annotation, got %v", got.Annotations)
+	}
+}
+
+// capability_id: rainbond.lifecycle.service-reconcile-rejects-foreign-owner
+func TestCreateKubeServiceRejectsForeignService(t *testing.T) {
+	existing := generatedService("java", "other-service")
+	desired := generatedService("java", "service-1")
+	client := k8sfake.NewSimpleClientset(existing)
+
+	err := CreateKubeService(client, desired.Namespace, desired)
+	if err == nil || !strings.Contains(err.Error(), "other-service") {
+		t.Fatalf("expected ownership conflict, got %v", err)
+	}
+}
+
+func TestCreateKubeServiceRejectsMissingOwnership(t *testing.T) {
+	desired := generatedService("java", "service-1")
+	delete(desired.Labels, serviceIDLabel)
+	client := k8sfake.NewSimpleClientset()
+
+	err := CreateKubeService(client, desired.Namespace, desired)
+	if err == nil || !strings.Contains(err.Error(), serviceIDLabel) {
+		t.Fatalf("expected missing ownership error, got %v", err)
+	}
+}
+
+func TestCreateKubeServiceRejectsHeadlessIdentityChange(t *testing.T) {
+	existing := generatedService("java", "service-1")
+	existing.Spec.ClusterIP = "10.0.0.8"
+	desired := generatedService("java", "service-1")
+	desired.Spec.ClusterIP = corev1.ClusterIPNone
+	client := k8sfake.NewSimpleClientset(existing)
+
+	err := CreateKubeService(client, desired.Namespace, desired)
+	if err == nil || !strings.Contains(err.Error(), "cluster IP mode") {
+		t.Fatalf("expected immutable cluster IP mode error, got %v", err)
+	}
+}
+
+func TestCreateKubeServiceReturnsUpdateError(t *testing.T) {
+	existing := generatedService("java", "service-1")
+	desired := generatedService("java", "service-1")
+	client := k8sfake.NewSimpleClientset(existing)
+	client.PrependReactor("update", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("update service failed")
+	})
+
+	err := CreateKubeService(client, desired.Namespace, desired)
+	if err == nil || !strings.Contains(err.Error(), "update service failed") {
+		t.Fatalf("expected update error, got %v", err)
+	}
+}
+
+func TestCreateKubeServiceDropsNodePortWhenChangingToClusterIP(t *testing.T) {
+	existing := generatedService("java", "service-1")
+	existing.Spec.Type = corev1.ServiceTypeNodePort
+	existing.Spec.ClusterIP = "10.0.0.8"
+	existing.Spec.Ports[0].NodePort = 30080
+	desired := generatedService("java", "service-1")
+	client := k8sfake.NewSimpleClientset(existing)
+
+	if err := CreateKubeService(client, desired.Namespace, desired); err != nil {
+		t.Fatalf("reconcile service type: %v", err)
+	}
+	got, err := client.CoreV1().Services(desired.Namespace).Get(context.Background(), desired.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get reconciled service: %v", err)
+	}
+	if got.Spec.Ports[0].NodePort != 0 {
+		t.Fatalf("expected node port to be cleared for ClusterIP service, got %d", got.Spec.Ports[0].NodePort)
+	}
+}
+
+func TestCreateKubeServiceRetriesUpdateConflict(t *testing.T) {
+	existing := generatedService("java", "service-1")
+	desired := generatedService("java", "service-1")
+	desired.Labels["version"] = "v2"
+	client := k8sfake.NewSimpleClientset(existing)
+	updateAttempts := 0
+	client.PrependReactor("update", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateAttempts++
+		if updateAttempts == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "services"},
+				desired.Name,
+				errors.New("concurrent update"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	if err := CreateKubeService(client, desired.Namespace, desired); err != nil {
+		t.Fatalf("reconcile service after conflict: %v", err)
+	}
+	if updateAttempts != 2 {
+		t.Fatalf("expected two update attempts, got %d", updateAttempts)
+	}
+}
+
+func TestServicePortsShareIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  corev1.ServicePort
+		existing corev1.ServicePort
+		want     bool
+	}{
+		{
+			name:     "matching named TCP ports",
+			desired:  corev1.ServicePort{Name: "http", Protocol: corev1.ProtocolTCP},
+			existing: corev1.ServicePort{Name: "http", Protocol: corev1.ProtocolTCP},
+			want:     true,
+		},
+		{
+			name:     "different protocols",
+			desired:  corev1.ServicePort{Name: "dns", Protocol: corev1.ProtocolUDP},
+			existing: corev1.ServicePort{Name: "dns", Protocol: corev1.ProtocolTCP},
+		},
+		{
+			name:     "different names",
+			desired:  corev1.ServicePort{Name: "http", Protocol: corev1.ProtocolTCP},
+			existing: corev1.ServicePort{Name: "https", Protocol: corev1.ProtocolTCP},
+		},
+		{
+			name:     "matching unnamed ports",
+			desired:  corev1.ServicePort{Port: 8080, Protocol: corev1.ProtocolTCP},
+			existing: corev1.ServicePort{Port: 8080, Protocol: corev1.ProtocolTCP},
+			want:     true,
+		},
+		{
+			name:     "different unnamed ports",
+			desired:  corev1.ServicePort{Port: 8080, Protocol: corev1.ProtocolTCP},
+			existing: corev1.ServicePort{Port: 9090, Protocol: corev1.ProtocolTCP},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := servicePortsShareIdentity(test.desired, test.existing); got != test.want {
+				t.Fatalf("expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}

--- a/worker/appm/controller/stop.go
+++ b/worker/appm/controller/stop.go
@@ -96,20 +96,9 @@ func (s *stopController) Begin() {
 func (s *stopController) stopOne(app v1.AppService) error {
 
 	var zero int64
-	//step 1: delete services
-	if services := app.GetServices(true); services != nil {
-		for _, service := range services {
-			if service != nil && service.Name != "" {
-				err := s.manager.client.CoreV1().Services(app.GetNamespace()).Delete(s.ctx, service.Name, metav1.DeleteOptions{
-					GracePeriodSeconds: &zero,
-				})
-				if err != nil && !errors.IsNotFound(err) {
-					return fmt.Errorf("delete service failure:%s", err.Error())
-				}
-			}
-		}
-	}
-	//step 2: delete secrets
+	// Keep generated Services so their cluster IPs and DNS identities survive stop and restart.
+	// Component deletion is responsible for removing them through the service garbage collector.
+	// step 1: delete secrets
 	if secrets := app.GetSecrets(true); secrets != nil {
 		for _, secret := range secrets {
 			if secret != nil && secret.Name != "" {
@@ -122,7 +111,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 			}
 		}
 	}
-	//step 3: delete ingress
+	// step 2: delete ingress
 	if ingresses, betaIngresses := app.GetIngress(true); ingresses != nil || betaIngresses != nil {
 		if ingresses != nil {
 			for _, ingress := range ingresses {
@@ -145,7 +134,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 		}
 
 	}
-	//step 4: delete configmap
+	// step 3: delete configmap
 	if configs := app.GetConfigMaps(); configs != nil {
 		for _, config := range configs {
 			if config != nil && config.Name != "" {
@@ -185,7 +174,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 		}
 		s.manager.store.OnDeletes(vm)
 	}
-	//step 5: delete statefulset or deployment
+	// step 4: delete statefulset or deployment
 	if statefulset := app.GetStatefulSet(); statefulset != nil {
 		err := s.manager.client.AppsV1().StatefulSets(app.GetNamespace()).Delete(s.ctx, statefulset.Name, metav1.DeleteOptions{})
 		if err != nil && !errors.IsNotFound(err) {
@@ -230,7 +219,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 		}
 		s.manager.store.OnDeletes(cronjob)
 	}
-	//step 6: delete all pod
+	// step 5: delete all pod
 	var gracePeriodSeconds int64
 	if pods := app.GetPods(true); pods != nil {
 		for _, pod := range pods {
@@ -244,7 +233,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 			}
 		}
 	}
-	//step 7: deleta all hpa
+	// step 6: delete all hpa
 	if hpas := app.GetHPAs(); len(hpas) != 0 {
 		for _, hpa := range hpas {
 			err := s.manager.client.AutoscalingV2().HorizontalPodAutoscalers(hpa.GetNamespace()).Delete(s.ctx, hpa.GetName(), metav1.DeleteOptions{})
@@ -261,7 +250,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 			}
 		}
 	}
-	//step 8: delete CR resource
+	// step 7: delete CR resource
 	if crd, _ := s.manager.store.GetCrd(store.ServiceMonitor); crd != nil {
 		if sms := app.GetServiceMonitors(true); len(sms) > 0 {
 			smClient, err := s.manager.store.GetServiceMonitorClient()
@@ -279,7 +268,7 @@ func (s *stopController) stopOne(app v1.AppService) error {
 		}
 	}
 
-	//step 9: waiting endpoint ready
+	// step 8: waiting endpoint ready
 	app.Logger.Info("Delete all app model success, will waiting app closed", event.GetLoggerOption("running"))
 	return s.WaitingReady(app)
 }

--- a/worker/appm/controller/stop_test.go
+++ b/worker/appm/controller/stop_test.go
@@ -1,10 +1,76 @@
 package controller
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/goodrain/rainbond/event"
+	"github.com/goodrain/rainbond/worker/appm/store"
+	appmtypes "github.com/goodrain/rainbond/worker/appm/types/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
+
+type closedAppStore struct {
+	store.Storer
+}
+
+func (closedAppStore) GetAppService(string) *appmtypes.AppService {
+	return nil
+}
+
+func (closedAppStore) GetCrd(string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	return nil, nil
+}
+
+// capability_id: rainbond.lifecycle.stop-preserves-service
+func TestStopPreservesGeneratedService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "java",
+			Namespace: namespace.Name,
+			Labels: map[string]string{
+				"creator":    "Rainbond",
+				"service_id": "service-1",
+			},
+		},
+		Spec: corev1.ServiceSpec{ClusterIP: "10.0.0.8"},
+	}
+	client := k8sfake.NewSimpleClientset(namespace, service)
+	logger := event.NewMockLogger(ctrl)
+	logger.EXPECT().Info(gomock.Any(), gomock.Any())
+
+	app := appmtypes.AppService{
+		AppServiceBase: appmtypes.AppServiceBase{ServiceID: "service-1", ServiceAlias: "java"},
+		Logger:         logger,
+	}
+	app.SetTenant(namespace)
+	app.SetService(service)
+
+	controller := &stopController{
+		manager: &Manager{client: client, store: closedAppStore{}},
+		ctx:     context.Background(),
+	}
+	if err := controller.stopOne(app); err != nil {
+		t.Fatalf("stop component: %v", err)
+	}
+
+	got, err := client.CoreV1().Services(namespace.Name).Get(context.Background(), service.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected service to remain after stop: %v", err)
+	}
+	if got.Spec.ClusterIP != service.Spec.ClusterIP {
+		t.Fatalf("expected cluster IP %q, got %q", service.Spec.ClusterIP, got.Spec.ClusterIP)
+	}
+}
 
 func TestShouldDeleteManifestWithRuntimeClient(t *testing.T) {
 	testCases := []struct {

--- a/worker/appm/controller/upgrade_test.go
+++ b/worker/appm/controller/upgrade_test.go
@@ -24,7 +24,14 @@ func configMapForTest(name string) *corev1.ConfigMap {
 
 func serviceForTest(name string) *corev1.Service {
 	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"creator":    "Rainbond",
+				"service_id": "service-1",
+			},
+		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{Port: 80}},
 		},

--- a/worker/appm/types/v1/v1.go
+++ b/worker/appm/types/v1/v1.go
@@ -572,6 +572,9 @@ func (a *AppService) DelEndpoints(ep *corev1.Endpoints) {
 
 // GetIngress get ingress
 func (a *AppService) GetIngress(canCopy bool) ([]*networkingv1.Ingress, []*betav1.Ingress) {
+	if len(a.ingresses) == 0 && len(a.betaIngresses) == 0 {
+		return nil, nil
+	}
 	if k8s.IsHighVersion() {
 		if canCopy {
 			cr := make([]*networkingv1.Ingress, len(a.ingresses))


### PR DESCRIPTION
## Summary
- keep Rainbond-managed Kubernetes Services during component stop and restart
- reconcile existing same-owner Services while preserving ClusterIP, IP family, UID/resourceVersion, and allocated NodePorts
- reject same-name Services owned by another component and add lifecycle regression coverage

## Behavior and compatibility
- Service DNS and ClusterIP remain stable while a component is stopped; endpoints are empty until workloads restart
- component deletion still removes retained Services through the existing service garbage collector
- custom-manifest Service lifecycle and public API/UI contracts are unchanged

## Verification
- go test -mod=mod ./...
- go build -mod=mod ./...
- go vet -mod=mod ./...
- go test -mod=mod -race ./worker/appm/controller -run TestStopPreservesGeneratedService\|TestCreateKubeService -count=1
- make check
- python3 scripts/validate_test_manifest.py

The default vendor-mode Go commands are currently blocked on origin/main because vendor/modules.txt is inconsistent with go.mod, so the full Go gates were run with -mod=mod without changing vendored dependencies.