### PR TITLE
feat: stream event logs over SSE

### DIFF
--- a/api/api_routers/version2/v2Routers.go
+++ b/api/api_routers/version2/v2Routers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/goodrain/rainbond/api/middleware"
 	dbmodel "github.com/goodrain/rainbond/db/model"
 	"github.com/goodrain/rainbond/pkg/apis/rainbond/v1alpha1"
+	"github.com/goodrain/rainbond/pkg/component/eventlog"
 	"github.com/goodrain/rainbond/pkg/component/k8s"
 	http2 "github.com/goodrain/rainbond/util/http"
 	"github.com/sirupsen/logrus"
@@ -128,6 +129,8 @@ func (v2 *V2) eventsRouter() chi.Router {
 	r.Get("/myteam", controller.GetManager().MyTeamsEvents)
 	// get target's event content
 	r.Get("/{eventID}/log", controller.GetManager().EventLog)
+	// stream target's event content
+	r.Get("/{eventID}/stream", eventlog.Default().SocketServer.PushEventMessageSSE)
 	return r
 }
 

--- a/api/eventlog/exit/web/event_stream_test.go
+++ b/api/eventlog/exit/web/event_stream_test.go
@@ -1,0 +1,327 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	eventlogdb "github.com/goodrain/rainbond/api/eventlog/db"
+
+	"golang.org/x/net/context"
+)
+
+type fakeEventMessageStore struct {
+	messages chan *eventlogdb.EventLogMessage
+
+	subscribeCalls int
+	subscribeMode  string
+	subscribeID    string
+	subscriberID   string
+
+	releaseCalls      int
+	releaseMode       string
+	releaseID         string
+	releaseSubscriber string
+}
+
+func (f *fakeEventMessageStore) WebSocketMessageChan(mode, eventID, subID string) chan *eventlogdb.EventLogMessage {
+	f.subscribeCalls++
+	f.subscribeMode = mode
+	f.subscribeID = eventID
+	f.subscriberID = subID
+	return f.messages
+}
+
+func (f *fakeEventMessageStore) RealseWebSocketMessageChan(mode, eventID, subID string) {
+	f.releaseCalls++
+	f.releaseMode = mode
+	f.releaseID = eventID
+	f.releaseSubscriber = subID
+}
+
+func (f *fakeEventMessageStore) assertReleasedOnce(t *testing.T, eventID string) {
+	t.Helper()
+	if f.subscribeCalls != 1 {
+		t.Fatalf("subscribe calls = %d, want 1", f.subscribeCalls)
+	}
+	if f.subscribeMode != "event" || f.subscribeID != eventID || f.subscriberID == "" {
+		t.Fatalf("unexpected subscription: mode=%q eventID=%q subscriberID=%q", f.subscribeMode, f.subscribeID, f.subscriberID)
+	}
+	if f.releaseCalls != 1 {
+		t.Fatalf("release calls = %d, want 1", f.releaseCalls)
+	}
+	if f.releaseMode != f.subscribeMode || f.releaseID != f.subscribeID || f.releaseSubscriber != f.subscriberID {
+		t.Fatalf("release does not match subscription: mode=%q eventID=%q subscriberID=%q", f.releaseMode, f.releaseID, f.releaseSubscriber)
+	}
+}
+
+type responseWriterWithoutFlusher struct {
+	header http.Header
+	status int
+	body   bytes.Buffer
+}
+
+func (w *responseWriterWithoutFlusher) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *responseWriterWithoutFlusher) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *responseWriterWithoutFlusher) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.body.Write(data)
+}
+
+type failingStreamResponseWriter struct {
+	header  http.Header
+	status  int
+	body    bytes.Buffer
+	writes  int
+	failAt  int
+	flushes int
+}
+
+func (w *failingStreamResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *failingStreamResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *failingStreamResponseWriter) Write(data []byte) (int, error) {
+	w.writes++
+	if w.writes == w.failAt {
+		return 0, errors.New("client disconnected")
+	}
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.body.Write(data)
+}
+
+func (w *failingStreamResponseWriter) Flush() {
+	w.flushes++
+}
+
+func TestPushEventMessageSSERejectsEmptyEventID(t *testing.T) {
+	server := &SocketServer{context: context.Background()}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/v2/events//stream", nil)
+
+	server.PushEventMessageSSE(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+	}
+}
+
+func TestStreamEventMessagesWritesHeadersAndCompleteJSONFrames(t *testing.T) {
+	eventID := "event-1"
+	message := &eventlogdb.EventLogMessage{
+		EventID: eventID,
+		Step:    "build",
+		Status:  "running",
+		Message: "building\nlayer 2",
+		Level:   "debug",
+		Time:    "2026-08-15T12:00:00+08:00",
+		Content: []byte("legacy websocket payload"),
+	}
+	messages := make(chan *eventlogdb.EventLogMessage, 2)
+	messages <- nil
+	messages <- message
+	close(messages)
+	store := &fakeEventMessageStore{messages: messages}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	streamEventMessages(response, request, eventID, store, make(chan struct{}), time.Hour)
+
+	wantJSON, err := json.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantBody := ": connected\n\ndata: " + string(wantJSON) + "\n\n"
+	if response.Body.String() != wantBody {
+		t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
+	}
+	wantHeaders := map[string]string{
+		"Content-Type":      "text/event-stream",
+		"Cache-Control":     "no-cache",
+		"Connection":        "keep-alive",
+		"X-Accel-Buffering": "no",
+	}
+	for name, want := range wantHeaders {
+		if got := response.Header().Get(name); got != want {
+			t.Errorf("header %s = %q, want %q", name, got, want)
+		}
+	}
+	if !response.Flushed {
+		t.Fatal("response was not flushed")
+	}
+	store.assertReleasedOnce(t, eventID)
+}
+
+func TestStreamEventMessagesStopsAfterTerminalMessage(t *testing.T) {
+	for _, terminalStep := range []string{"last", "callback"} {
+		t.Run(terminalStep, func(t *testing.T) {
+			eventID := "event-terminal-" + terminalStep
+			terminal := &eventlogdb.EventLogMessage{EventID: eventID, Step: terminalStep, Status: "done", Message: "finished"}
+			messages := make(chan *eventlogdb.EventLogMessage, 2)
+			messages <- terminal
+			messages <- &eventlogdb.EventLogMessage{EventID: eventID, Step: "after-terminal", Message: "must not be sent"}
+			store := &fakeEventMessageStore{messages: messages}
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			streamEventMessages(response, request, eventID, store, make(chan struct{}), time.Hour)
+
+			terminalJSON, err := json.Marshal(terminal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantBody := ": connected\n\ndata: " + string(terminalJSON) + "\n\n"
+			if response.Body.String() != wantBody {
+				t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
+			}
+			if len(messages) != 1 {
+				t.Fatalf("messages left = %d, want 1", len(messages))
+			}
+			store.assertReleasedOnce(t, eventID)
+		})
+	}
+}
+
+func TestStreamEventMessagesSendsHeartbeat(t *testing.T) {
+	eventID := "event-heartbeat"
+	store := &fakeEventMessageStore{messages: make(chan *eventlogdb.EventLogMessage)}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	serverDone := make(chan struct{})
+	time.AfterFunc(20*time.Millisecond, func() { close(serverDone) })
+
+	streamEventMessages(response, request, eventID, store, serverDone, time.Millisecond)
+
+	if !strings.Contains(response.Body.String(), ": ping\n\n") {
+		t.Fatalf("body %q does not contain heartbeat", response.Body.String())
+	}
+	store.assertReleasedOnce(t, eventID)
+}
+
+func TestStreamEventMessagesExitsAndReleasesSubscription(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*http.Request, chan *eventlogdb.EventLogMessage, chan struct{}) *http.Request
+	}{
+		{
+			name: "request canceled",
+			configure: func(request *http.Request, _ chan *eventlogdb.EventLogMessage, _ chan struct{}) *http.Request {
+				ctx, cancel := context.WithCancel(request.Context())
+				cancel()
+				return request.WithContext(ctx)
+			},
+		},
+		{
+			name: "server canceled",
+			configure: func(request *http.Request, _ chan *eventlogdb.EventLogMessage, serverDone chan struct{}) *http.Request {
+				close(serverDone)
+				return request
+			},
+		},
+		{
+			name: "message channel closed",
+			configure: func(request *http.Request, messages chan *eventlogdb.EventLogMessage, _ chan struct{}) *http.Request {
+				close(messages)
+				return request
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			eventID := "event-exit"
+			messages := make(chan *eventlogdb.EventLogMessage)
+			serverDone := make(chan struct{})
+			request := test.configure(httptest.NewRequest(http.MethodGet, "/", nil), messages, serverDone)
+			store := &fakeEventMessageStore{messages: messages}
+			response := httptest.NewRecorder()
+
+			streamEventMessages(response, request, eventID, store, serverDone, time.Hour)
+
+			if response.Body.String() != ": connected\n\n" {
+				t.Fatalf("body = %q, want connected frame only", response.Body.String())
+			}
+			store.assertReleasedOnce(t, eventID)
+		})
+	}
+}
+
+func TestStreamEventMessagesExitsOnWriteFailure(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		failAt int
+	}{
+		{name: "initial frame", failAt: 1},
+		{name: "data frame", failAt: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			eventID := "event-write-failure"
+			messages := make(chan *eventlogdb.EventLogMessage, 1)
+			messages <- &eventlogdb.EventLogMessage{EventID: eventID, Step: "build", Message: "building"}
+			store := &fakeEventMessageStore{messages: messages}
+			response := &failingStreamResponseWriter{failAt: test.failAt}
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			streamEventMessages(response, request, eventID, store, make(chan struct{}), time.Hour)
+
+			store.assertReleasedOnce(t, eventID)
+		})
+	}
+}
+
+func TestStreamEventMessagesRejectsInvalidStreamRequests(t *testing.T) {
+	t.Run("empty event ID", func(t *testing.T) {
+		store := &fakeEventMessageStore{messages: make(chan *eventlogdb.EventLogMessage)}
+		response := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		streamEventMessages(response, request, "", store, make(chan struct{}), time.Hour)
+
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
+		}
+		if store.subscribeCalls != 0 || store.releaseCalls != 0 {
+			t.Fatalf("invalid request subscribed %d times and released %d times", store.subscribeCalls, store.releaseCalls)
+		}
+	})
+
+	t.Run("response writer without flusher", func(t *testing.T) {
+		store := &fakeEventMessageStore{messages: make(chan *eventlogdb.EventLogMessage)}
+		response := &responseWriterWithoutFlusher{}
+		request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+		streamEventMessages(response, request, "event-no-flusher", store, make(chan struct{}), time.Hour)
+
+		if response.status != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want %d", response.status, http.StatusInternalServerError)
+		}
+		if store.subscribeCalls != 0 || store.releaseCalls != 0 {
+			t.Fatalf("invalid request subscribed %d times and released %d times", store.subscribeCalls, store.releaseCalls)
+		}
+	})
+}

--- a/api/eventlog/exit/web/manager.go
+++ b/api/eventlog/exit/web/manager.go
@@ -21,13 +21,14 @@ package web
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/goodrain/rainbond/api/eventlog/conf"
-	"github.com/goodrain/rainbond/api/eventlog/store"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/goodrain/rainbond/api/eventlog/conf"
+	"github.com/goodrain/rainbond/api/eventlog/db"
+	"github.com/goodrain/rainbond/api/eventlog/store"
 	"github.com/goodrain/rainbond/util"
 	httputil "github.com/goodrain/rainbond/util/http"
 
@@ -36,9 +37,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	_ "k8s.io/component-base/metrics/prometheus/version"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	_ "k8s.io/component-base/metrics/prometheus/version"
 )
 
 // SocketServer socket 服务
@@ -157,6 +158,80 @@ func (s *SocketServer) PushEventMessage(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+}
+
+type eventMessageStore interface {
+	WebSocketMessageChan(mode, eventID, subID string) chan *db.EventLogMessage
+	RealseWebSocketMessageChan(mode, eventID, subID string)
+}
+
+// PushEventMessageSSE streams event log messages to an SSE client.
+func (s *SocketServer) PushEventMessageSSE(w http.ResponseWriter, r *http.Request) {
+	streamEventMessages(w, r, chi.URLParam(r, "eventID"), s.storemanager, s.context.Done(), 20*time.Second)
+}
+
+func streamEventMessages(w http.ResponseWriter, r *http.Request, eventID string, messageStore eventMessageStore, serverDone <-chan struct{}, heartbeatInterval time.Duration) {
+	if strings.TrimSpace(eventID) == "" {
+		http.Error(w, "Event ID can not be empty", http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	subscriberID := uuid.New().String()
+	messages := messageStore.WebSocketMessageChan("event", eventID, subscriberID)
+	defer messageStore.RealseWebSocketMessageChan("event", eventID, subscriberID)
+	if messages == nil {
+		http.Error(w, "Event stream unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	if _, err := fmt.Fprint(w, ": connected\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-serverDone:
+			return
+		case message, ok := <-messages:
+			if !ok {
+				return
+			}
+			if message == nil {
+				continue
+			}
+			payload, err := json.Marshal(message)
+			if err != nil {
+				return
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+				return
+			}
+			flusher.Flush()
+			if message.Step == "last" || message.Step == "callback" {
+				return
+			}
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
 }
 
 func (s *SocketServer) PushDockerLog(w http.ResponseWriter, r *http.Request) {

--- a/api/eventlog/store/barrel.go
+++ b/api/eventlog/store/barrel.go
@@ -110,6 +110,9 @@ type readEventBarrel struct {
 	subSocketChan map[string]chan *db.EventLogMessage
 	subLock       sync.Mutex
 	updateTime    time.Time
+	// activeUsers is guarded by readMessageStore.lock. It prevents the barrel
+	// from being recycled while an operation is waiting for subLock.
+	activeUsers int
 	// 新增字段
 	eventID   string    // 事件ID
 	fileStore FileStore // 文件存储
@@ -148,6 +151,9 @@ func (r *readEventBarrel) empty() {
 }
 
 func (r *readEventBarrel) insertMessage(message *db.EventLogMessage) {
+	r.subLock.Lock()
+	defer r.subLock.Unlock()
+
 	r.updateTime = time.Now()
 
 	// 1. 立即持久化到文件（不在内存累积）
@@ -158,9 +164,6 @@ func (r *readEventBarrel) insertMessage(message *db.EventLogMessage) {
 	}
 
 	// 2. 只转发给当前活跃的订阅者（不缓存）
-	r.subLock.Lock()
-	defer r.subLock.Unlock()
-
 	for _, v := range r.subSocketChan {
 		select {
 		case v <- message:
@@ -170,13 +173,7 @@ func (r *readEventBarrel) insertMessage(message *db.EventLogMessage) {
 	}
 }
 
-func (r *readEventBarrel) pushCashMessage(ch chan *db.EventLogMessage, subID string) {
-	// 先注册订阅通道，确保实时消息不会丢失
-	r.subLock.Lock()
-	r.subSocketChan[subID] = ch
-	r.subLock.Unlock()
-
-	// 再从文件读取历史消息并推送
+func (r *readEventBarrel) pushCashMessage(ch chan *db.EventLogMessage) {
 	if r.fileStore != nil && r.eventID != "" {
 		messages, err := r.fileStore.ReadLast(r.eventID, 1000)
 		if err != nil {
@@ -186,12 +183,7 @@ func (r *readEventBarrel) pushCashMessage(ch chan *db.EventLogMessage, subID str
 				if m.Content == nil {
 					rebuildMessageContent(m)
 				}
-				select {
-				case ch <- m:
-				case <-time.After(5 * time.Second):
-					logrus.Warnf("Timeout pushing history for event %s", r.eventID)
-					return
-				}
+				ch <- m
 			}
 		}
 	}
@@ -200,15 +192,18 @@ func (r *readEventBarrel) pushCashMessage(ch chan *db.EventLogMessage, subID str
 // 增加socket订阅
 func (r *readEventBarrel) addSubChan(subID string) chan *db.EventLogMessage {
 	r.subLock.Lock()
+	defer r.subLock.Unlock()
+
 	if sub, ok := r.subSocketChan[subID]; ok {
-		r.subLock.Unlock()
 		return sub
 	}
-	r.subLock.Unlock()
 
 	ch := make(chan *db.EventLogMessage, 1024)
-	// 异步推送历史消息（从文件读取）
-	go r.pushCashMessage(ch, subID)
+	// Keep the per-event lock while reading and enqueueing history. Inserts use
+	// the same lock, so live messages can only follow the complete replay and
+	// cannot be returned by ReadLast and then delivered a second time as live.
+	r.pushCashMessage(ch)
+	r.subSocketChan[subID] = ch
 	return ch
 }
 

--- a/api/eventlog/store/read_message_store.go
+++ b/api/eventlog/store/read_message_store.go
@@ -48,43 +48,49 @@ func (h *readMessageStore) InsertMessage(message *db.EventLogMessage) {
 	if message == nil || message.EventID == "" {
 		return
 	}
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	if ba, ok := h.barrels[message.EventID]; ok {
-		ba.insertMessage(message)
-	} else {
-		ba := h.pool.Get().(*readEventBarrel)
-		// 注入eventID和fileStore
-		ba.eventID = message.EventID
-		ba.fileStore = h.fileStore
-		ba.insertMessage(message)
-		h.barrels[message.EventID] = ba
-	}
+	ba := h.acquireBarrel(message.EventID, true)
+	defer h.releaseBarrel(ba)
+	ba.insertMessage(message)
 }
 func (h *readMessageStore) GetMonitorData() *db.MonitorData {
 	return nil
 }
 
 func (h *readMessageStore) SubChan(eventID, subID string) chan *db.EventLogMessage {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	if ba, ok := h.barrels[eventID]; ok {
-		return ba.addSubChan(subID)
-	}
-	ba := h.pool.Get().(*readEventBarrel)
-	// 注入eventID和fileStore
-	ba.eventID = eventID
-	ba.fileStore = h.fileStore
-	ba.updateTime = time.Now()
-	h.barrels[eventID] = ba
+	ba := h.acquireBarrel(eventID, true)
+	defer h.releaseBarrel(ba)
 	return ba.addSubChan(subID)
 }
 func (h *readMessageStore) RealseSubChan(eventID, subID string) {
+	ba := h.acquireBarrel(eventID, false)
+	if ba == nil {
+		return
+	}
+	defer h.releaseBarrel(ba)
+	ba.delSubChan(subID)
+}
+
+func (h *readMessageStore) acquireBarrel(eventID string, create bool) *readEventBarrel {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	if ba, ok := h.barrels[eventID]; ok {
-		ba.delSubChan(subID)
+	ba, ok := h.barrels[eventID]
+	if !ok && create {
+		ba = h.pool.Get().(*readEventBarrel)
+		ba.eventID = eventID
+		ba.fileStore = h.fileStore
+		ba.updateTime = time.Now()
+		h.barrels[eventID] = ba
 	}
+	if ba != nil {
+		ba.activeUsers++
+	}
+	return ba
+}
+
+func (h *readMessageStore) releaseBarrel(ba *readEventBarrel) {
+	h.lock.Lock()
+	ba.activeUsers--
+	h.lock.Unlock()
 }
 func (h *readMessageStore) Run() {
 	go h.Gc()
@@ -101,13 +107,16 @@ func (h *readMessageStore) Gc() {
 			return
 		}
 
-		if len(h.barrels) == 0 {
-			continue
-		}
-
 		var gcEvent []string
 		h.lock.Lock()
+		if len(h.barrels) == 0 {
+			h.lock.Unlock()
+			continue
+		}
 		for k, v := range h.barrels {
+			if v.activeUsers > 0 {
+				continue
+			}
 			// 改进GC策略：
 			// 1. 超时未活跃的barrel（1分钟）且无订阅者
 			if v.updateTime.Add(time.Minute * 1).Before(time.Now()) {

--- a/api/eventlog/store/read_message_store_test.go
+++ b/api/eventlog/store/read_message_store_test.go
@@ -1,0 +1,236 @@
+// Copyright (C) 2014-2018 Goodrain Co., Ltd.
+// RAINBOND, Application Management Platform
+
+package store
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goodrain/rainbond/api/eventlog/db"
+)
+
+type blockingReplayFileStore struct {
+	lock sync.Mutex
+
+	messages []*db.EventLogMessage
+
+	readStarted  chan struct{}
+	releaseRead  chan struct{}
+	appendCalled chan struct{}
+	readOnce     sync.Once
+	appendOnce   sync.Once
+}
+
+func newBlockingReplayFileStore(messages ...*db.EventLogMessage) *blockingReplayFileStore {
+	return &blockingReplayFileStore{
+		messages:     append([]*db.EventLogMessage(nil), messages...),
+		readStarted:  make(chan struct{}),
+		releaseRead:  make(chan struct{}),
+		appendCalled: make(chan struct{}),
+	}
+}
+
+func (s *blockingReplayFileStore) Append(_ string, message *db.EventLogMessage) error {
+	s.lock.Lock()
+	s.messages = append(s.messages, message)
+	s.lock.Unlock()
+	s.appendOnce.Do(func() { close(s.appendCalled) })
+	return nil
+}
+
+func (s *blockingReplayFileStore) ReadAll(string) ([]*db.EventLogMessage, error) {
+	return s.readLast(0), nil
+}
+
+func (s *blockingReplayFileStore) ReadLast(_ string, n int) ([]*db.EventLogMessage, error) {
+	s.readOnce.Do(func() { close(s.readStarted) })
+	<-s.releaseRead
+	return s.readLast(n), nil
+}
+
+func (s *blockingReplayFileStore) readLast(n int) []*db.EventLogMessage {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	start := 0
+	if n > 0 && len(s.messages) > n {
+		start = len(s.messages) - n
+	}
+	return append([]*db.EventLogMessage(nil), s.messages[start:]...)
+}
+
+func (s *blockingReplayFileStore) Delete(string) error   { return nil }
+func (s *blockingReplayFileStore) Clean(time.Time) error { return nil }
+func (s *blockingReplayFileStore) Close() error          { return nil }
+
+func newReadEventBarrelForTest(fileStore FileStore) *readEventBarrel {
+	return &readEventBarrel{
+		eventID:       "event-1",
+		fileStore:     fileStore,
+		subSocketChan: make(map[string]chan *db.EventLogMessage),
+	}
+}
+
+func TestReadEventBarrelReplaysHistoryBeforeLiveWithoutDuplicates(t *testing.T) {
+	history := &db.EventLogMessage{EventID: "event-1", Message: "history"}
+	live := &db.EventLogMessage{EventID: "event-1", Message: "live"}
+	fileStore := newBlockingReplayFileStore(history)
+	barrel := newReadEventBarrelForTest(fileStore)
+
+	subscription := make(chan chan *db.EventLogMessage, 1)
+	go func() {
+		subscription <- barrel.addSubChan("subscriber-1")
+	}()
+	<-fileStore.readStarted
+
+	insertDone := make(chan struct{})
+	go func() {
+		barrel.insertMessage(live)
+		close(insertDone)
+	}()
+
+	appendedBeforeReplayFinished := false
+	select {
+	case <-fileStore.appendCalled:
+		appendedBeforeReplayFinished = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(fileStore.releaseRead)
+	ch := <-subscription
+	<-insertDone
+
+	if appendedBeforeReplayFinished {
+		t.Error("live message was persisted while history replay was still in progress")
+	}
+
+	assertMessage(t, ch, "history")
+	assertMessage(t, ch, "live")
+	select {
+	case message := <-ch:
+		t.Fatalf("received duplicate message after history replay: %#v", message)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestReadEventBarrelReleaseWaitsForHistoryReplay(t *testing.T) {
+	fileStore := newBlockingReplayFileStore()
+	barrel := newReadEventBarrelForTest(fileStore)
+
+	subscription := make(chan chan *db.EventLogMessage, 1)
+	go func() {
+		subscription <- barrel.addSubChan("subscriber-1")
+	}()
+	<-fileStore.readStarted
+
+	releaseDone := make(chan struct{})
+	go func() {
+		barrel.delSubChan("subscriber-1")
+		close(releaseDone)
+	}()
+
+	releasedDuringReplay := false
+	select {
+	case <-releaseDone:
+		releasedDuringReplay = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(fileStore.releaseRead)
+	ch := <-subscription
+	<-releaseDone
+
+	if releasedDuringReplay {
+		t.Error("subscriber channel was released while history replay was still in progress")
+	}
+	if _, ok := <-ch; ok {
+		t.Error("subscriber channel remains open after release")
+	}
+}
+
+func TestReadEventBarrelPreservesIdenticalLiveMessages(t *testing.T) {
+	fileStore := newBlockingReplayFileStore()
+	barrel := newReadEventBarrelForTest(fileStore)
+
+	subscription := make(chan chan *db.EventLogMessage, 1)
+	go func() {
+		subscription <- barrel.addSubChan("subscriber-1")
+	}()
+	<-fileStore.readStarted
+	close(fileStore.releaseRead)
+	ch := <-subscription
+
+	first := &db.EventLogMessage{EventID: "event-1", Message: "same message"}
+	second := &db.EventLogMessage{EventID: "event-1", Message: "same message"}
+	barrel.insertMessage(first)
+	barrel.insertMessage(second)
+
+	assertMessage(t, ch, "same message")
+	assertMessage(t, ch, "same message")
+}
+
+func TestReadMessageStoreReplayDoesNotBlockOtherEvents(t *testing.T) {
+	fileStore := newBlockingReplayFileStore()
+	messageStore := &readMessageStore{
+		barrels:   make(map[string]*readEventBarrel),
+		fileStore: fileStore,
+	}
+	messageStore.pool = &sync.Pool{
+		New: func() interface{} {
+			return &readEventBarrel{
+				subSocketChan: make(map[string]chan *db.EventLogMessage),
+				fileStore:     fileStore,
+			}
+		},
+	}
+
+	subscription := make(chan chan *db.EventLogMessage, 1)
+	go func() {
+		subscription <- messageStore.SubChan("event-1", "subscriber-1")
+	}()
+	<-fileStore.readStarted
+
+	insertDone := make(chan struct{})
+	go func() {
+		messageStore.InsertMessage(&db.EventLogMessage{EventID: "event-2", Message: "live"})
+		close(insertDone)
+	}()
+
+	select {
+	case <-insertDone:
+	case <-time.After(time.Second):
+		t.Error("history replay for one event blocked inserts for another event")
+	}
+
+	close(fileStore.releaseRead)
+	ch := <-subscription
+	messageStore.RealseSubChan("event-1", "subscriber-1")
+	closed := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Error("subscriber channel remains open after release")
+	}
+}
+
+func assertMessage(t *testing.T, ch <-chan *db.EventLogMessage, want string) {
+	t.Helper()
+	select {
+	case message, ok := <-ch:
+		if !ok {
+			t.Fatalf("subscriber channel closed before receiving %q", want)
+		}
+		if message == nil || message.Message != want {
+			t.Fatalf("received message %#v, want %q", message, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for message %q", want)
+	}
+}

--- a/pkg/interceptors/http.go
+++ b/pkg/interceptors/http.go
@@ -123,11 +123,7 @@ func Timeout(timeout time.Duration) func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			// 长时请求豁免：日志流、插件后端代理（含 SSE / 长连接）使用更长的超时。
 			// 这里用每请求的局部变量，避免直接改写闭包捕获的 timeout 而污染后续所有请求。
-			effectiveTimeout := timeout
-			if strings.Contains(r.URL.Path, "logs") ||
-				strings.Contains(r.URL.Path, "/platform/backend/plugins/") {
-				effectiveTimeout = 1 * time.Hour
-			}
+			effectiveTimeout := requestTimeout(r.URL.Path, timeout)
 			ctx, cancel := context.WithTimeout(r.Context(), effectiveTimeout)
 			defer func() {
 				cancel()
@@ -141,4 +137,22 @@ func Timeout(timeout time.Duration) func(next http.Handler) http.Handler {
 		}
 		return http.HandlerFunc(fn)
 	}
+}
+
+func requestTimeout(path string, defaultTimeout time.Duration) time.Duration {
+	if strings.Contains(path, "logs") ||
+		strings.Contains(path, "/platform/backend/plugins/") ||
+		isEventLogStreamPath(path) {
+		return time.Hour
+	}
+	return defaultTimeout
+}
+
+func isEventLogStreamPath(path string) bool {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	return len(parts) == 4 &&
+		parts[0] == "v2" &&
+		parts[1] == "events" &&
+		parts[2] != "" &&
+		parts[3] == "stream"
 }

--- a/pkg/interceptors/http_test.go
+++ b/pkg/interceptors/http_test.go
@@ -1,0 +1,65 @@
+// RAINBOND, Application Management Platform
+// Copyright (C) 2021-2024 Goodrain Co., Ltd.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package interceptors
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRequestTimeout(t *testing.T) {
+	defaultTimeout := 5 * time.Second
+	tests := []struct {
+		name string
+		path string
+		want time.Duration
+	}{
+		{
+			name: "pod logs use the long timeout",
+			path: "/v2/tenants/team/services/service/pods/pod/logs",
+			want: time.Hour,
+		},
+		{
+			name: "plugin streams use the long timeout",
+			path: "/v2/platform/backend/plugins/example/events",
+			want: time.Hour,
+		},
+		{
+			name: "event streams use the long timeout",
+			path: "/v2/events/event-1/stream",
+			want: time.Hour,
+		},
+		{
+			name: "event log history keeps the default timeout",
+			path: "/v2/events/event-1/log",
+			want: defaultTimeout,
+		},
+		{
+			name: "event stream suffix is matched precisely",
+			path: "/v2/events/event-1/stream/archive",
+			want: defaultTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requestTimeout(tt.path, defaultTimeout); got != tt.want {
+				t.Fatalf("requestTimeout(%q) = %s, want %s", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `GET /v2/events/{eventID}/stream` for event-log SSE
- reuse the existing event message store and subscription lifecycle
- serialize history replay and live delivery per event so history stays ordered and replay/live races do not duplicate messages
- preserve legitimate identical log messages and make subscription release safe during replay and GC
- stream complete event-log JSON frames with heartbeats and terminal shutdown
- exempt only the exact stream route from the default request timeout while retaining a one-hour bound

## Compatibility
- URL and JSON payloads are unchanged from the initial SSE contract
- legacy `/event_log` WebSocket and PubSub event consumers keep the same interfaces
- no Markdown or YAML design files are included

## Verification
- `go test ./api/eventlog/store ./api/eventlog/exit/web ./pkg/interceptors`
- `go test -race ./api/eventlog/store ./api/eventlog/exit/web ./pkg/interceptors`
- `go build ./...`
- `go vet ./...`
- `make check`

## Consumer
- goodrain/rainbond-ui#1903

The UI reuses the existing rainbond-console `/console/sse/*` proxy, so no Console code change is required.