### PR TITLE
fix: mark event log replay boundary

### DIFF
--- a/api/eventlog/exit/web/event_stream_test.go
+++ b/api/eventlog/exit/web/event_stream_test.go
@@ -11,11 +11,43 @@ import (
 	"time"
 
 	eventlogdb "github.com/goodrain/rainbond/api/eventlog/db"
+	eventlogstore "github.com/goodrain/rainbond/api/eventlog/store"
 
+	"github.com/go-chi/chi"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 )
 
+type legacyEventStoreManager struct {
+	webSocketSubscribeCalls int
+}
+
+var _ eventlogstore.Manager = (*legacyEventStoreManager)(nil)
+
+func (m *legacyEventStoreManager) ReceiveMessageChan() chan []byte    { return nil }
+func (m *legacyEventStoreManager) SubMessageChan() chan [][]byte      { return nil }
+func (m *legacyEventStoreManager) PubMessageChan() chan [][]byte      { return nil }
+func (m *legacyEventStoreManager) DockerLogMessageChan() chan []byte  { return nil }
+func (m *legacyEventStoreManager) GetDockerLogs(string, int) []string { return nil }
+func (m *legacyEventStoreManager) MonitorMessageChan() chan [][]byte  { return nil }
+func (m *legacyEventStoreManager) NewMonitorMessageChan() chan []byte { return nil }
+func (m *legacyEventStoreManager) Run() error                         { return nil }
+func (m *legacyEventStoreManager) Stop()                              {}
+func (m *legacyEventStoreManager) Monitor() []eventlogdb.MonitorData  { return nil }
+func (m *legacyEventStoreManager) Error() chan error                  { return nil }
+func (m *legacyEventStoreManager) HealthCheck() map[string]string     { return nil }
+func (m *legacyEventStoreManager) RealseWebSocketMessageChan(string, string, string) {
+}
+func (m *legacyEventStoreManager) WebSocketMessageChan(string, string, string) chan *eventlogdb.EventLogMessage {
+	m.webSocketSubscribeCalls++
+	return nil
+}
+func (m *legacyEventStoreManager) Scrape(chan<- prometheus.Metric, string, string, string) error {
+	return nil
+}
+
 type fakeEventMessageStore struct {
+	history  []*eventlogdb.EventLogMessage
 	messages chan *eventlogdb.EventLogMessage
 
 	subscribeCalls int
@@ -27,6 +59,13 @@ type fakeEventMessageStore struct {
 	releaseMode       string
 	releaseID         string
 	releaseSubscriber string
+
+	streamSubscribeCalls int
+	streamSubscribeID    string
+	streamSubscriberID   string
+	streamReleaseCalls   int
+	streamReleaseID      string
+	streamReleaseSubID   string
 }
 
 func (f *fakeEventMessageStore) WebSocketMessageChan(mode, eventID, subID string) chan *eventlogdb.EventLogMessage {
@@ -44,6 +83,19 @@ func (f *fakeEventMessageStore) RealseWebSocketMessageChan(mode, eventID, subID 
 	f.releaseSubscriber = subID
 }
 
+func (f *fakeEventMessageStore) EventStreamMessageChan(eventID, subID string) ([]*eventlogdb.EventLogMessage, chan *eventlogdb.EventLogMessage) {
+	f.streamSubscribeCalls++
+	f.streamSubscribeID = eventID
+	f.streamSubscriberID = subID
+	return f.history, f.messages
+}
+
+func (f *fakeEventMessageStore) ReleaseEventStreamMessageChan(eventID, subID string) {
+	f.streamReleaseCalls++
+	f.streamReleaseID = eventID
+	f.streamReleaseSubID = subID
+}
+
 func (f *fakeEventMessageStore) assertReleasedOnce(t *testing.T, eventID string) {
 	t.Helper()
 	if f.subscribeCalls != 1 {
@@ -59,6 +111,36 @@ func (f *fakeEventMessageStore) assertReleasedOnce(t *testing.T, eventID string)
 		t.Fatalf("release does not match subscription: mode=%q eventID=%q subscriberID=%q", f.releaseMode, f.releaseID, f.releaseSubscriber)
 	}
 }
+
+func (f *fakeEventMessageStore) assertEventStreamReleasedOnce(t *testing.T, eventID string) {
+	t.Helper()
+	if f.streamSubscribeCalls != 1 {
+		t.Fatalf("stream subscribe calls = %d, want 1", f.streamSubscribeCalls)
+	}
+	if f.streamSubscribeID != eventID || f.streamSubscriberID == "" {
+		t.Fatalf("unexpected stream subscription: eventID=%q subscriberID=%q", f.streamSubscribeID, f.streamSubscriberID)
+	}
+	if f.streamReleaseCalls != 1 {
+		t.Fatalf("stream release calls = %d, want 1", f.streamReleaseCalls)
+	}
+	if f.streamReleaseID != f.streamSubscribeID || f.streamReleaseSubID != f.streamSubscriberID {
+		t.Fatalf("stream release does not match subscription: eventID=%q subscriberID=%q", f.streamReleaseID, f.streamReleaseSubID)
+	}
+	if f.subscribeCalls != 0 || f.releaseCalls != 0 {
+		t.Fatalf("SSE used legacy websocket subscription: subscribe=%d release=%d", f.subscribeCalls, f.releaseCalls)
+	}
+}
+
+func eventDataFrame(t *testing.T, message *eventlogdb.EventLogMessage) string {
+	t.Helper()
+	payload, err := json.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "data: " + string(payload) + "\n\n"
+}
+
+const replayCompleteFrame = "event: replay-complete\ndata: {}\n\n"
 
 type responseWriterWithoutFlusher struct {
 	header http.Header
@@ -92,6 +174,34 @@ type failingStreamResponseWriter struct {
 	failAt  int
 	flushes int
 }
+
+type callbackStreamResponseWriter struct {
+	header    http.Header
+	body      bytes.Buffer
+	writes    int
+	callback  func()
+	triggerAt int
+}
+
+func (w *callbackStreamResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *callbackStreamResponseWriter) WriteHeader(int) {}
+
+func (w *callbackStreamResponseWriter) Write(data []byte) (int, error) {
+	w.writes++
+	written, err := w.body.Write(data)
+	if w.writes == w.triggerAt {
+		w.callback()
+	}
+	return written, err
+}
+
+func (w *callbackStreamResponseWriter) Flush() {}
 
 func (w *failingStreamResponseWriter) Header() http.Header {
 	if w.header == nil {
@@ -131,6 +241,139 @@ func TestPushEventMessageSSERejectsEmptyEventID(t *testing.T) {
 	}
 }
 
+func TestPushEventMessageSSERejectsManagerWithoutEventStreamCapability(t *testing.T) {
+	manager := &legacyEventStoreManager{}
+	server := &SocketServer{context: context.Background(), storemanager: manager}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/v2/events/event-1/stream", nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("eventID", "event-1")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+
+	server.PushEventMessageSSE(response, request)
+
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusInternalServerError)
+	}
+	if response.Header().Get("Content-Type") == "text/event-stream" {
+		t.Fatal("unsupported manager started an SSE response")
+	}
+	if manager.webSocketSubscribeCalls != 0 {
+		t.Fatalf("legacy WebSocket subscription calls = %d, want 0", manager.webSocketSubscribeCalls)
+	}
+}
+
+func TestStreamEventMessagesWritesHistoryBoundaryThenLive(t *testing.T) {
+	eventID := "event-replay"
+	history := []*eventlogdb.EventLogMessage{
+		{EventID: eventID, Step: "build", Status: "running", Message: "same", Level: "debug", Time: "2026-08-16T10:00:00+08:00"},
+		{EventID: eventID, Step: "build", Status: "running", Message: "same", Level: "debug", Time: "2026-08-16T10:00:00+08:00"},
+	}
+	live := []*eventlogdb.EventLogMessage{
+		{EventID: eventID, Step: "build", Status: "running", Message: "same", Level: "debug", Time: "2026-08-16T10:00:01+08:00"},
+		{EventID: eventID, Step: "build", Status: "running", Message: "same", Level: "debug", Time: "2026-08-16T10:00:01+08:00"},
+	}
+	messages := make(chan *eventlogdb.EventLogMessage, len(live))
+	for _, message := range live {
+		messages <- message
+	}
+	close(messages)
+	store := &fakeEventMessageStore{history: history, messages: messages}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	streamEventMessages(response, request, eventID, store, make(chan struct{}), time.Hour)
+
+	wantBody := ": connected\n\n"
+	for _, message := range history {
+		wantBody += eventDataFrame(t, message)
+	}
+	wantBody += replayCompleteFrame
+	for _, message := range live {
+		wantBody += eventDataFrame(t, message)
+	}
+	if response.Body.String() != wantBody {
+		t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
+	}
+	if got := strings.Count(response.Body.String(), "event: replay-complete\n"); got != 1 {
+		t.Fatalf("replay-complete frames = %d, want 1", got)
+	}
+	store.assertEventStreamReleasedOnce(t, eventID)
+}
+
+func TestStreamEventMessagesClosesAfterHistoricalTerminalAndBoundary(t *testing.T) {
+	for _, terminalStep := range []string{"last", "callback"} {
+		t.Run(terminalStep, func(t *testing.T) {
+			eventID := "event-history-terminal-" + terminalStep
+			terminal := &eventlogdb.EventLogMessage{EventID: eventID, Step: terminalStep, Status: "done", Message: "finished"}
+			history := []*eventlogdb.EventLogMessage{
+				terminal,
+				{EventID: eventID, Step: "after-terminal", Message: "must not be sent"},
+			}
+			messages := make(chan *eventlogdb.EventLogMessage, 1)
+			messages <- &eventlogdb.EventLogMessage{EventID: eventID, Step: "live", Message: "must not be sent"}
+			store := &fakeEventMessageStore{history: history, messages: messages}
+			response := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			streamEventMessages(response, request, eventID, store, make(chan struct{}), time.Hour)
+
+			wantBody := ": connected\n\n" + eventDataFrame(t, terminal) + replayCompleteFrame
+			if response.Body.String() != wantBody {
+				t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
+			}
+			if len(messages) != 1 {
+				t.Fatalf("live messages left = %d, want 1", len(messages))
+			}
+			store.assertEventStreamReleasedOnce(t, eventID)
+		})
+	}
+}
+
+func TestStreamEventMessagesStopsHistoryReplayImmediatelyWhenCanceled(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		configure func(*http.Request, chan struct{}) (*http.Request, func())
+	}{
+		{
+			name: "request canceled",
+			configure: func(request *http.Request, _ chan struct{}) (*http.Request, func()) {
+				requestContext, cancel := context.WithCancel(request.Context())
+				return request.WithContext(requestContext), cancel
+			},
+		},
+		{
+			name: "server canceled",
+			configure: func(request *http.Request, serverDone chan struct{}) (*http.Request, func()) {
+				return request, func() { close(serverDone) }
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			eventID := "event-history-cancel"
+			history := []*eventlogdb.EventLogMessage{
+				{EventID: eventID, Step: "build", Message: "first"},
+				{EventID: eventID, Step: "build", Message: "must not be sent"},
+			}
+			store := &fakeEventMessageStore{history: history, messages: make(chan *eventlogdb.EventLogMessage)}
+			serverDone := make(chan struct{})
+			request, cancel := test.configure(httptest.NewRequest(http.MethodGet, "/", nil), serverDone)
+			response := &callbackStreamResponseWriter{callback: cancel, triggerAt: 2}
+
+			streamEventMessages(response, request, eventID, store, serverDone, time.Hour)
+
+			wantBody := ": connected\n\n" + eventDataFrame(t, history[0])
+			if response.body.String() != wantBody {
+				t.Fatalf("body = %q, want %q", response.body.String(), wantBody)
+			}
+			if strings.Contains(response.body.String(), "replay-complete") {
+				t.Fatal("replay boundary was written after cancellation")
+			}
+			store.assertEventStreamReleasedOnce(t, eventID)
+		})
+	}
+}
+
 func TestStreamEventMessagesWritesHeadersAndCompleteJSONFrames(t *testing.T) {
 	eventID := "event-1"
 	message := &eventlogdb.EventLogMessage{
@@ -156,7 +399,7 @@ func TestStreamEventMessagesWritesHeadersAndCompleteJSONFrames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantBody := ": connected\n\ndata: " + string(wantJSON) + "\n\n"
+	wantBody := ": connected\n\n" + replayCompleteFrame + "data: " + string(wantJSON) + "\n\n"
 	if response.Body.String() != wantBody {
 		t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
 	}
@@ -174,7 +417,7 @@ func TestStreamEventMessagesWritesHeadersAndCompleteJSONFrames(t *testing.T) {
 	if !response.Flushed {
 		t.Fatal("response was not flushed")
 	}
-	store.assertReleasedOnce(t, eventID)
+	store.assertEventStreamReleasedOnce(t, eventID)
 }
 
 func TestStreamEventMessagesStopsAfterTerminalMessage(t *testing.T) {
@@ -195,14 +438,14 @@ func TestStreamEventMessagesStopsAfterTerminalMessage(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			wantBody := ": connected\n\ndata: " + string(terminalJSON) + "\n\n"
+			wantBody := ": connected\n\n" + replayCompleteFrame + "data: " + string(terminalJSON) + "\n\n"
 			if response.Body.String() != wantBody {
 				t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
 			}
 			if len(messages) != 1 {
 				t.Fatalf("messages left = %d, want 1", len(messages))
 			}
-			store.assertReleasedOnce(t, eventID)
+			store.assertEventStreamReleasedOnce(t, eventID)
 		})
 	}
 }
@@ -220,13 +463,14 @@ func TestStreamEventMessagesSendsHeartbeat(t *testing.T) {
 	if !strings.Contains(response.Body.String(), ": ping\n\n") {
 		t.Fatalf("body %q does not contain heartbeat", response.Body.String())
 	}
-	store.assertReleasedOnce(t, eventID)
+	store.assertEventStreamReleasedOnce(t, eventID)
 }
 
 func TestStreamEventMessagesExitsAndReleasesSubscription(t *testing.T) {
 	tests := []struct {
-		name      string
-		configure func(*http.Request, chan *eventlogdb.EventLogMessage, chan struct{}) *http.Request
+		name               string
+		configure          func(*http.Request, chan *eventlogdb.EventLogMessage, chan struct{}) *http.Request
+		wantReplayBoundary bool
 	}{
 		{
 			name: "request canceled",
@@ -244,7 +488,8 @@ func TestStreamEventMessagesExitsAndReleasesSubscription(t *testing.T) {
 			},
 		},
 		{
-			name: "message channel closed",
+			name:               "message channel closed",
+			wantReplayBoundary: true,
 			configure: func(request *http.Request, messages chan *eventlogdb.EventLogMessage, _ chan struct{}) *http.Request {
 				close(messages)
 				return request
@@ -263,33 +508,51 @@ func TestStreamEventMessagesExitsAndReleasesSubscription(t *testing.T) {
 
 			streamEventMessages(response, request, eventID, store, serverDone, time.Hour)
 
-			if response.Body.String() != ": connected\n\n" {
-				t.Fatalf("body = %q, want connected frame only", response.Body.String())
+			wantBody := ": connected\n\n"
+			if test.wantReplayBoundary {
+				wantBody += replayCompleteFrame
 			}
-			store.assertReleasedOnce(t, eventID)
+			if response.Body.String() != wantBody {
+				t.Fatalf("body = %q, want %q", response.Body.String(), wantBody)
+			}
+			store.assertEventStreamReleasedOnce(t, eventID)
 		})
 	}
 }
 
 func TestStreamEventMessagesExitsOnWriteFailure(t *testing.T) {
 	for _, test := range []struct {
-		name   string
-		failAt int
+		name     string
+		failAt   int
+		history  []*eventlogdb.EventLogMessage
+		messages []*eventlogdb.EventLogMessage
 	}{
 		{name: "initial frame", failAt: 1},
-		{name: "data frame", failAt: 2},
+		{
+			name:    "history data frame",
+			failAt:  2,
+			history: []*eventlogdb.EventLogMessage{{EventID: "event-write-failure", Step: "build", Message: "history"}},
+		},
+		{name: "replay boundary", failAt: 2},
+		{
+			name:     "live data frame",
+			failAt:   3,
+			messages: []*eventlogdb.EventLogMessage{{EventID: "event-write-failure", Step: "build", Message: "live"}},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			eventID := "event-write-failure"
-			messages := make(chan *eventlogdb.EventLogMessage, 1)
-			messages <- &eventlogdb.EventLogMessage{EventID: eventID, Step: "build", Message: "building"}
-			store := &fakeEventMessageStore{messages: messages}
+			messages := make(chan *eventlogdb.EventLogMessage, len(test.messages))
+			for _, message := range test.messages {
+				messages <- message
+			}
+			store := &fakeEventMessageStore{history: test.history, messages: messages}
 			response := &failingStreamResponseWriter{failAt: test.failAt}
 			request := httptest.NewRequest(http.MethodGet, "/", nil)
 
 			streamEventMessages(response, request, eventID, store, make(chan struct{}), time.Hour)
 
-			store.assertReleasedOnce(t, eventID)
+			store.assertEventStreamReleasedOnce(t, eventID)
 		})
 	}
 }
@@ -305,8 +568,8 @@ func TestStreamEventMessagesRejectsInvalidStreamRequests(t *testing.T) {
 		if response.Code != http.StatusBadRequest {
 			t.Fatalf("status = %d, want %d", response.Code, http.StatusBadRequest)
 		}
-		if store.subscribeCalls != 0 || store.releaseCalls != 0 {
-			t.Fatalf("invalid request subscribed %d times and released %d times", store.subscribeCalls, store.releaseCalls)
+		if store.subscribeCalls != 0 || store.releaseCalls != 0 || store.streamSubscribeCalls != 0 || store.streamReleaseCalls != 0 {
+			t.Fatalf("invalid request subscribed through legacy=%d stream=%d and released through legacy=%d stream=%d", store.subscribeCalls, store.streamSubscribeCalls, store.releaseCalls, store.streamReleaseCalls)
 		}
 	})
 
@@ -320,8 +583,8 @@ func TestStreamEventMessagesRejectsInvalidStreamRequests(t *testing.T) {
 		if response.status != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", response.status, http.StatusInternalServerError)
 		}
-		if store.subscribeCalls != 0 || store.releaseCalls != 0 {
-			t.Fatalf("invalid request subscribed %d times and released %d times", store.subscribeCalls, store.releaseCalls)
+		if store.subscribeCalls != 0 || store.releaseCalls != 0 || store.streamSubscribeCalls != 0 || store.streamReleaseCalls != 0 {
+			t.Fatalf("invalid request subscribed through legacy=%d stream=%d and released through legacy=%d stream=%d", store.subscribeCalls, store.streamSubscribeCalls, store.releaseCalls, store.streamReleaseCalls)
 		}
 	})
 }

--- a/api/eventlog/exit/web/manager.go
+++ b/api/eventlog/exit/web/manager.go
@@ -161,13 +161,23 @@ func (s *SocketServer) PushEventMessage(w http.ResponseWriter, r *http.Request) 
 }
 
 type eventMessageStore interface {
-	WebSocketMessageChan(mode, eventID, subID string) chan *db.EventLogMessage
-	RealseWebSocketMessageChan(mode, eventID, subID string)
+	EventStreamMessageChan(eventID, subID string) ([]*db.EventLogMessage, chan *db.EventLogMessage)
+	ReleaseEventStreamMessageChan(eventID, subID string)
 }
 
 // PushEventMessageSSE streams event log messages to an SSE client.
 func (s *SocketServer) PushEventMessageSSE(w http.ResponseWriter, r *http.Request) {
-	streamEventMessages(w, r, chi.URLParam(r, "eventID"), s.storemanager, s.context.Done(), 20*time.Second)
+	eventID := chi.URLParam(r, "eventID")
+	if strings.TrimSpace(eventID) == "" {
+		http.Error(w, "Event ID can not be empty", http.StatusBadRequest)
+		return
+	}
+	messageStore, ok := s.storemanager.(eventMessageStore)
+	if !ok {
+		http.Error(w, "Event stream unavailable", http.StatusInternalServerError)
+		return
+	}
+	streamEventMessages(w, r, eventID, messageStore, s.context.Done(), 20*time.Second)
 }
 
 func streamEventMessages(w http.ResponseWriter, r *http.Request, eventID string, messageStore eventMessageStore, serverDone <-chan struct{}, heartbeatInterval time.Duration) {
@@ -183,8 +193,8 @@ func streamEventMessages(w http.ResponseWriter, r *http.Request, eventID string,
 	}
 
 	subscriberID := uuid.New().String()
-	messages := messageStore.WebSocketMessageChan("event", eventID, subscriberID)
-	defer messageStore.RealseWebSocketMessageChan("event", eventID, subscriberID)
+	history, messages := messageStore.EventStreamMessageChan(eventID, subscriberID)
+	defer messageStore.ReleaseEventStreamMessageChan(eventID, subscriberID)
 	if messages == nil {
 		http.Error(w, "Event stream unavailable", http.StatusInternalServerError)
 		return
@@ -198,6 +208,47 @@ func streamEventMessages(w http.ResponseWriter, r *http.Request, eventID string,
 		return
 	}
 	flusher.Flush()
+
+	historyTerminal := false
+	for _, message := range history {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-serverDone:
+			return
+		default:
+		}
+		if message == nil {
+			continue
+		}
+		payload, err := json.Marshal(message)
+		if err != nil {
+			return
+		}
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+			return
+		}
+		flusher.Flush()
+		if message.Step == "last" || message.Step == "callback" {
+			historyTerminal = true
+			break
+		}
+	}
+
+	select {
+	case <-r.Context().Done():
+		return
+	case <-serverDone:
+		return
+	default:
+	}
+	if _, err := fmt.Fprint(w, "event: replay-complete\ndata: {}\n\n"); err != nil {
+		return
+	}
+	flusher.Flush()
+	if historyTerminal {
+		return
+	}
 
 	heartbeat := time.NewTicker(heartbeatInterval)
 	defer heartbeat.Stop()

--- a/api/eventlog/store/barrel.go
+++ b/api/eventlog/store/barrel.go
@@ -174,19 +174,26 @@ func (r *readEventBarrel) insertMessage(message *db.EventLogMessage) {
 }
 
 func (r *readEventBarrel) pushCashMessage(ch chan *db.EventLogMessage) {
+	for _, message := range r.readLastMessages() {
+		ch <- message
+	}
+}
+
+func (r *readEventBarrel) readLastMessages() []*db.EventLogMessage {
 	if r.fileStore != nil && r.eventID != "" {
 		messages, err := r.fileStore.ReadLast(r.eventID, 1000)
 		if err != nil {
 			logrus.Errorf("Failed to read history for event %s: %v", r.eventID, err)
-		} else {
-			for _, m := range messages {
-				if m.Content == nil {
-					rebuildMessageContent(m)
-				}
-				ch <- m
+			return nil
+		}
+		for _, message := range messages {
+			if message.Content == nil {
+				rebuildMessageContent(message)
 			}
 		}
+		return messages
 	}
+	return nil
 }
 
 // 增加socket订阅
@@ -205,6 +212,23 @@ func (r *readEventBarrel) addSubChan(subID string) chan *db.EventLogMessage {
 	r.pushCashMessage(ch)
 	r.subSocketChan[subID] = ch
 	return ch
+}
+
+// addEventStreamSubChan atomically snapshots persisted history and registers a
+// live subscriber. History is returned separately so the SSE transport can
+// mark the replay boundary without changing legacy WebSocket/PubSub messages.
+func (r *readEventBarrel) addEventStreamSubChan(subID string) ([]*db.EventLogMessage, chan *db.EventLogMessage) {
+	r.subLock.Lock()
+	defer r.subLock.Unlock()
+
+	if sub, ok := r.subSocketChan[subID]; ok {
+		return nil, sub
+	}
+
+	history := r.readLastMessages()
+	live := make(chan *db.EventLogMessage, 1024)
+	r.subSocketChan[subID] = live
+	return history, live
 }
 
 // 删除socket订阅

--- a/api/eventlog/store/manager.go
+++ b/api/eventlog/store/manager.go
@@ -100,7 +100,7 @@ func NewManager(conf conf.EventStoreConf, log *logrus.Entry) (Manager, error) {
 		errChan:               make(chan error),
 	}
 	handle := NewStore("handle", storeManager)
-	read := NewStore("read", storeManager)
+	read := NewStore("read", storeManager).(*readMessageStore)
 	docker := NewStore("docker_log", storeManager)
 	newmonitor := NewStore("newmonitor", storeManager)
 	storeManager.handleMessageStore = handle
@@ -114,7 +114,7 @@ type storeManager struct {
 	cancel                 func()
 	context                context.Context
 	handleMessageStore     MessageStore
-	readMessageStore       MessageStore
+	readMessageStore       *readMessageStore
 	dockerLogStore         MessageStore
 	newmonitorMessageStore MessageStore
 	receiveChan            chan []byte
@@ -250,6 +250,13 @@ func (s *storeManager) WebSocketMessageChan(mode, eventID, subID string) chan *d
 		return ch
 	}
 	return nil
+}
+
+// EventStreamMessageChan returns an atomic event history snapshot and a live
+// channel dedicated to SSE. Legacy WebSocket and PubSub subscribers continue
+// to use WebSocketMessageChan and retain their existing replay semantics.
+func (s *storeManager) EventStreamMessageChan(eventID, subID string) ([]*db2.EventLogMessage, chan *db2.EventLogMessage) {
+	return s.readMessageStore.EventStreamMessageChan(eventID, subID)
 }
 
 func (s *storeManager) Run() error {
@@ -519,6 +526,10 @@ func (s *storeManager) RealseWebSocketMessageChan(mode string, eventID, subID st
 	if mode == "newmonitor" {
 		s.newmonitorMessageStore.RealseSubChan(eventID, subID)
 	}
+}
+
+func (s *storeManager) ReleaseEventStreamMessageChan(eventID, subID string) {
+	s.readMessageStore.RealseSubChan(eventID, subID)
 }
 
 func (s *storeManager) Stop() {

--- a/api/eventlog/store/read_message_store.go
+++ b/api/eventlog/store/read_message_store.go
@@ -61,6 +61,13 @@ func (h *readMessageStore) SubChan(eventID, subID string) chan *db.EventLogMessa
 	defer h.releaseBarrel(ba)
 	return ba.addSubChan(subID)
 }
+
+func (h *readMessageStore) EventStreamMessageChan(eventID, subID string) ([]*db.EventLogMessage, chan *db.EventLogMessage) {
+	ba := h.acquireBarrel(eventID, true)
+	defer h.releaseBarrel(ba)
+	return ba.addEventStreamSubChan(subID)
+}
+
 func (h *readMessageStore) RealseSubChan(eventID, subID string) {
 	ba := h.acquireBarrel(eventID, false)
 	if ba == nil {

--- a/api/eventlog/store/read_message_store_test.go
+++ b/api/eventlog/store/read_message_store_test.go
@@ -73,6 +73,22 @@ func newReadEventBarrelForTest(fileStore FileStore) *readEventBarrel {
 	}
 }
 
+func newReadMessageStoreForTest(fileStore FileStore) *readMessageStore {
+	messageStore := &readMessageStore{
+		barrels:   make(map[string]*readEventBarrel),
+		fileStore: fileStore,
+	}
+	messageStore.pool = &sync.Pool{
+		New: func() interface{} {
+			return &readEventBarrel{
+				subSocketChan: make(map[string]chan *db.EventLogMessage),
+				fileStore:     fileStore,
+			}
+		},
+	}
+	return messageStore
+}
+
 func TestReadEventBarrelReplaysHistoryBeforeLiveWithoutDuplicates(t *testing.T) {
 	history := &db.EventLogMessage{EventID: "event-1", Message: "history"}
 	live := &db.EventLogMessage{EventID: "event-1", Message: "live"}
@@ -171,20 +187,152 @@ func TestReadEventBarrelPreservesIdenticalLiveMessages(t *testing.T) {
 	assertMessage(t, ch, "same message")
 }
 
+func TestReadEventBarrelEventStreamSnapshotAndLiveAreAtomic(t *testing.T) {
+	history := &db.EventLogMessage{EventID: "event-1", Message: "same message"}
+	live := &db.EventLogMessage{EventID: "event-1", Message: "same message"}
+	fileStore := newBlockingReplayFileStore(history)
+	barrel := newReadEventBarrelForTest(fileStore)
+
+	type subscriptionResult struct {
+		history []*db.EventLogMessage
+		live    chan *db.EventLogMessage
+	}
+	subscription := make(chan subscriptionResult, 1)
+	go func() {
+		historyMessages, liveMessages := barrel.addEventStreamSubChan("sse-1")
+		subscription <- subscriptionResult{history: historyMessages, live: liveMessages}
+	}()
+	<-fileStore.readStarted
+
+	insertDone := make(chan struct{})
+	go func() {
+		barrel.insertMessage(live)
+		close(insertDone)
+	}()
+
+	select {
+	case <-fileStore.appendCalled:
+		t.Fatal("live message was persisted before the SSE history snapshot completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(fileStore.releaseRead)
+	result := <-subscription
+	<-insertDone
+
+	if len(result.history) != 1 || result.history[0].Message != "same message" {
+		t.Fatalf("history = %#v, want one preserved message", result.history)
+	}
+	assertMessage(t, result.live, "same message")
+	select {
+	case message := <-result.live:
+		t.Fatalf("received duplicate message across history/live boundary: %#v", message)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	barrel.delSubChan("sse-1")
+	if _, ok := <-result.live; ok {
+		t.Fatal("SSE live channel remains open after release")
+	}
+}
+
+func TestReadEventBarrelLegacySubscriptionStillReplaysThroughChannel(t *testing.T) {
+	history := &db.EventLogMessage{EventID: "event-1", Message: "legacy history"}
+	fileStore := newBlockingReplayFileStore(history)
+	barrel := newReadEventBarrelForTest(fileStore)
+
+	subscription := make(chan chan *db.EventLogMessage, 1)
+	go func() {
+		subscription <- barrel.addSubChan("websocket-1")
+	}()
+	<-fileStore.readStarted
+	close(fileStore.releaseRead)
+	legacyMessages := <-subscription
+
+	assertMessage(t, legacyMessages, "legacy history")
+	barrel.delSubChan("websocket-1")
+}
+
+func TestStoreManagerKeepsEventStreamAndLegacySubscriptionsSeparate(t *testing.T) {
+	history := &db.EventLogMessage{EventID: "event-1", Message: "history"}
+	fileStore := newBlockingReplayFileStore(history)
+	close(fileStore.releaseRead)
+	messageStore := newReadMessageStoreForTest(fileStore)
+	manager := &storeManager{readMessageStore: messageStore}
+
+	streamHistory, streamLive := manager.EventStreamMessageChan("event-1", "sse-1")
+	if len(streamHistory) != 1 || streamHistory[0].Message != "history" {
+		t.Fatalf("SSE history = %#v, want one history message", streamHistory)
+	}
+	select {
+	case message := <-streamLive:
+		t.Fatalf("SSE live channel unexpectedly replayed history: %#v", message)
+	default:
+	}
+	manager.ReleaseEventStreamMessageChan("event-1", "sse-1")
+	if _, ok := <-streamLive; ok {
+		t.Fatal("SSE live channel remains open after release")
+	}
+
+	legacy := manager.WebSocketMessageChan("event", "event-1", "websocket-1")
+	assertMessage(t, legacy, "history")
+	manager.RealseWebSocketMessageChan("event", "event-1", "websocket-1")
+	if _, ok := <-legacy; ok {
+		t.Fatal("legacy WebSocket channel remains open after release")
+	}
+}
+
+func TestReadMessageStoreEventStreamSubscriptionIsSafeFromGC(t *testing.T) {
+	fileStore := newBlockingReplayFileStore()
+	messageStore := newReadMessageStoreForTest(fileStore)
+
+	type subscriptionResult struct {
+		history []*db.EventLogMessage
+		live    chan *db.EventLogMessage
+	}
+	subscription := make(chan subscriptionResult, 1)
+	go func() {
+		history, live := messageStore.EventStreamMessageChan("event-1", "sse-1")
+		subscription <- subscriptionResult{history: history, live: live}
+	}()
+	<-fileStore.readStarted
+
+	messageStore.lock.Lock()
+	barrel := messageStore.barrels["event-1"]
+	activeUsers := barrel.activeUsers
+	messageStore.lock.Unlock()
+	if activeUsers != 1 {
+		t.Fatalf("active users during replay = %d, want 1 so GC cannot recycle the barrel", activeUsers)
+	}
+
+	close(fileStore.releaseRead)
+	result := <-subscription
+	messageStore.lock.Lock()
+	activeUsers = barrel.activeUsers
+	currentBarrel := messageStore.barrels["event-1"]
+	messageStore.lock.Unlock()
+	if activeUsers != 0 {
+		t.Fatalf("active users after subscription = %d, want 0", activeUsers)
+	}
+	if currentBarrel != barrel {
+		t.Fatal("event barrel was replaced while the SSE subscription was being registered")
+	}
+	barrel.subLock.Lock()
+	_, registered := barrel.subSocketChan["sse-1"]
+	barrel.subLock.Unlock()
+	if !registered {
+		t.Fatal("SSE subscriber was not registered before the barrel became eligible for GC checks")
+	}
+
+	messageStore.RealseSubChan("event-1", "sse-1")
+	if _, ok := <-result.live; ok {
+		t.Fatal("SSE live channel remains open after release")
+	}
+}
+
 func TestReadMessageStoreReplayDoesNotBlockOtherEvents(t *testing.T) {
 	fileStore := newBlockingReplayFileStore()
-	messageStore := &readMessageStore{
-		barrels:   make(map[string]*readEventBarrel),
-		fileStore: fileStore,
-	}
-	messageStore.pool = &sync.Pool{
-		New: func() interface{} {
-			return &readEventBarrel{
-				subSocketChan: make(map[string]chan *db.EventLogMessage),
-				fileStore:     fileStore,
-			}
-		},
-	}
+	messageStore := newReadMessageStoreForTest(fileStore)
 
 	subscription := make(chan chan *db.EventLogMessage, 1)
 	go func() {


### PR DESCRIPTION
## Summary

- split the event-log SSE subscription into an atomic history snapshot and live channel
- emit a replay-complete SSE event between replayed history and live messages
- keep the exported store Manager contract and legacy WebSocket/PubSub behavior unchanged
- stop history replay promptly when the request or server is cancelled

## Why

The UI loads event history over HTTP before opening the SSE stream. The stream also replays its persisted history, so the overlap was rendered twice. The explicit boundary lets the UI reconcile only the replayed portion while preserving identical live log lines.

## Validation

- targeted eventlog tests and repeated concurrency tests
- go test -race for eventlog web/store packages
- go test ./api/eventlog/...
- go build ./...
- go vet ./...
- make check
- git diff --check

No Markdown or YAML design files are included.