### PR TITLE
fix: preserve cross-application volume mounts during upgrade

### DIFF
--- a/api/handler/service.go
+++ b/api/handler/service.go
@@ -3697,11 +3697,45 @@ func (s *ServiceAction) SyncComponentVolumeRels(tx *gorm.DB, app *dbmodel.Applic
 	if err != nil {
 		return err
 	}
-	var appComponentIDs []string
+	volumeComponentIDs := make(map[string]struct{})
 	for _, ac := range appComponents {
-		appComponentIDs = append(appComponentIDs, ac.ServiceID)
+		volumeComponentIDs[ac.ServiceID] = struct{}{}
 	}
-	existVolume, err := s.getExistVolumes(appComponentIDs)
+	// A component can mount a shared volume owned by a component in another
+	// application. Resolve those providers first so only components belonging
+	// to the same tenant are included when existing volumes are queried.
+	externalProviderIDs := make(map[string]struct{})
+	for _, component := range components {
+		for _, volumeRelation := range component.VolumeRelations {
+			providerID := volumeRelation.DependServiceID
+			if providerID == "" {
+				continue
+			}
+			if _, ok := volumeComponentIDs[providerID]; !ok {
+				externalProviderIDs[providerID] = struct{}{}
+			}
+		}
+	}
+	if len(externalProviderIDs) > 0 {
+		providerIDs := make([]string, 0, len(externalProviderIDs))
+		for providerID := range externalProviderIDs {
+			providerIDs = append(providerIDs, providerID)
+		}
+		providers, err := db.GetManager().TenantServiceDao().GetServiceByIDs(providerIDs)
+		if err != nil {
+			return err
+		}
+		for _, provider := range providers {
+			if _, requested := externalProviderIDs[provider.ServiceID]; requested && provider.TenantID == app.TenantID {
+				volumeComponentIDs[provider.ServiceID] = struct{}{}
+			}
+		}
+	}
+	componentIDsForVolumes := make([]string, 0, len(volumeComponentIDs))
+	for componentID := range volumeComponentIDs {
+		componentIDsForVolumes = append(componentIDsForVolumes, componentID)
+	}
+	existVolume, err := s.getExistVolumes(componentIDsForVolumes)
 	if err != nil {
 		return err
 	}

--- a/api/handler/service_sync_volume_relations_test.go
+++ b/api/handler/service_sync_volume_relations_test.go
@@ -1,0 +1,279 @@
+// Copyright (C) 2014-2024 Goodrain Co., Ltd.
+// RAINBOND, Application Management Platform
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version. For any non-GPL usage of Rainbond,
+// one or multiple Commercial Licenses authorized by Goodrain Co., Ltd.
+// must be obtained first.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	apimodel "github.com/goodrain/rainbond/api/model"
+	"github.com/goodrain/rainbond/db"
+	dbdao "github.com/goodrain/rainbond/db/dao"
+	dbmodel "github.com/goodrain/rainbond/db/model"
+	"github.com/jinzhu/gorm"
+)
+
+const (
+	syncVolumeAppID               = "consumer-app-id"
+	syncVolumeTenantID            = "tenant-id"
+	syncVolumeConsumerComponentID = "consumer-component-id"
+	syncVolumeProviderComponentID = "provider-component-id"
+	syncVolumeName                = "shared-config"
+	syncVolumeMountPath           = "/etc/example/config.yaml"
+)
+
+type syncVolumeRelationTestManager struct {
+	db.Manager
+	serviceDao       dbdao.TenantServiceDao
+	volumeDao        dbdao.TenantServiceVolumeDao
+	mountRelationDao dbdao.TenantServiceMountRelationDao
+}
+
+func (m syncVolumeRelationTestManager) TenantServiceDao() dbdao.TenantServiceDao {
+	return m.serviceDao
+}
+
+func (m syncVolumeRelationTestManager) TenantServiceVolumeDao() dbdao.TenantServiceVolumeDao {
+	return m.volumeDao
+}
+
+func (m syncVolumeRelationTestManager) TenantServiceMountRelationDaoTransactions(*gorm.DB) dbdao.TenantServiceMountRelationDao {
+	return m.mountRelationDao
+}
+
+type syncVolumeRelationTenantServiceDao struct {
+	dbdao.TenantServiceDao
+	services            []*dbmodel.TenantServices
+	externalServices    []*dbmodel.TenantServices
+	externalServicesErr error
+	requestedAppID      string
+	requestedServiceIDs []string
+}
+
+func (d *syncVolumeRelationTenantServiceDao) ListByAppID(appID string) ([]*dbmodel.TenantServices, error) {
+	d.requestedAppID = appID
+	return d.services, nil
+}
+
+func (d *syncVolumeRelationTenantServiceDao) GetServiceByIDs(serviceIDs []string) ([]*dbmodel.TenantServices, error) {
+	d.requestedServiceIDs = append([]string(nil), serviceIDs...)
+	return d.externalServices, d.externalServicesErr
+}
+
+type syncVolumeRelationVolumeDao struct {
+	dbdao.TenantServiceVolumeDao
+	providerVolume *dbmodel.TenantServiceVolume
+	requestedIDs   []string
+}
+
+func (d *syncVolumeRelationVolumeDao) ListVolumesByComponentIDs(componentIDs []string) ([]*dbmodel.TenantServiceVolume, error) {
+	d.requestedIDs = append([]string(nil), componentIDs...)
+	if d.providerVolume == nil {
+		return nil, nil
+	}
+	for _, componentID := range componentIDs {
+		if componentID == d.providerVolume.ServiceID {
+			return []*dbmodel.TenantServiceVolume{d.providerVolume}, nil
+		}
+	}
+	return nil, nil
+}
+
+type syncVolumeRelationMountDao struct {
+	dbdao.TenantServiceMountRelationDao
+	deletedComponentIDs []string
+	createdRelations    []*dbmodel.TenantServiceMountRelation
+}
+
+func (d *syncVolumeRelationMountDao) DeleteByComponentIDs(componentIDs []string) error {
+	d.deletedComponentIDs = append([]string(nil), componentIDs...)
+	return nil
+}
+
+func (d *syncVolumeRelationMountDao) CreateOrUpdateVolumeRelsInBatch(relations []*dbmodel.TenantServiceMountRelation) error {
+	d.createdRelations = append([]*dbmodel.TenantServiceMountRelation(nil), relations...)
+	return nil
+}
+
+func setSyncVolumeRelationTestManager(t *testing.T, manager syncVolumeRelationTestManager) {
+	t.Helper()
+	originalManager := db.GetManager()
+	db.SetTestManager(manager)
+	t.Cleanup(func() {
+		db.SetTestManager(originalManager)
+	})
+}
+
+func syncVolumeRelationTestComponent() *apimodel.Component {
+	return &apimodel.Component{
+		ComponentBase: apimodel.ComponentBase{ComponentID: syncVolumeConsumerComponentID},
+		VolumeRelations: []apimodel.VolumeRelation{
+			{
+				MountPath:        syncVolumeMountPath,
+				DependServiceID:  syncVolumeProviderComponentID,
+				DependVolumeName: syncVolumeName,
+			},
+		},
+	}
+}
+
+// capability_id: rainbond.app-upgrade.cross-app-config-mount
+func TestSyncComponentVolumeRelsPreservesCrossApplicationConfigFileMount(t *testing.T) {
+	const hostPath = "/grdata/services/provider/shared-config"
+	serviceDao := &syncVolumeRelationTenantServiceDao{
+		services: []*dbmodel.TenantServices{{ServiceID: syncVolumeConsumerComponentID}},
+		externalServices: []*dbmodel.TenantServices{
+			{ServiceID: syncVolumeProviderComponentID, TenantID: syncVolumeTenantID},
+		},
+	}
+	volumeDao := &syncVolumeRelationVolumeDao{
+		providerVolume: &dbmodel.TenantServiceVolume{
+			ServiceID:  syncVolumeProviderComponentID,
+			VolumeName: syncVolumeName,
+			HostPath:   hostPath,
+			VolumeType: dbmodel.ConfigFileVolumeType.String(),
+		},
+	}
+	mountDao := &syncVolumeRelationMountDao{}
+	setSyncVolumeRelationTestManager(t, syncVolumeRelationTestManager{
+		serviceDao:       serviceDao,
+		volumeDao:        volumeDao,
+		mountRelationDao: mountDao,
+	})
+
+	err := (&ServiceAction{}).SyncComponentVolumeRels(nil, &dbmodel.Application{
+		AppID:    syncVolumeAppID,
+		TenantID: syncVolumeTenantID,
+	}, []*apimodel.Component{syncVolumeRelationTestComponent()})
+	if err != nil {
+		t.Fatalf("sync component volume relations: %v", err)
+	}
+
+	if serviceDao.requestedAppID != syncVolumeAppID {
+		t.Fatalf("expected application lookup for %q, got %q", syncVolumeAppID, serviceDao.requestedAppID)
+	}
+	if !containsSyncVolumeString(serviceDao.requestedServiceIDs, syncVolumeProviderComponentID) {
+		t.Fatalf("expected external provider lookup to include %q, got %v", syncVolumeProviderComponentID, serviceDao.requestedServiceIDs)
+	}
+	if !containsSyncVolumeString(volumeDao.requestedIDs, syncVolumeProviderComponentID) {
+		t.Fatalf("expected volume lookup to include cross-application provider %q, got %v", syncVolumeProviderComponentID, volumeDao.requestedIDs)
+	}
+	if len(mountDao.deletedComponentIDs) != 1 || mountDao.deletedComponentIDs[0] != syncVolumeConsumerComponentID {
+		t.Fatalf("expected existing relation deletion for %q, got %v", syncVolumeConsumerComponentID, mountDao.deletedComponentIDs)
+	}
+	if len(mountDao.createdRelations) != 1 {
+		t.Fatalf("expected one recreated mount relation, got %d", len(mountDao.createdRelations))
+	}
+	relation := mountDao.createdRelations[0]
+	if relation.TenantID != syncVolumeTenantID ||
+		relation.ServiceID != syncVolumeConsumerComponentID ||
+		relation.DependServiceID != syncVolumeProviderComponentID ||
+		relation.VolumeName != syncVolumeName ||
+		relation.VolumePath != syncVolumeMountPath ||
+		relation.HostPath != hostPath ||
+		relation.VolumeType != dbmodel.ConfigFileVolumeType.String() {
+		t.Fatalf("recreated mount relation does not preserve the shared config-file mount: %#v", relation)
+	}
+}
+
+// capability_id: rainbond.app-upgrade.cross-app-config-mount
+func TestSyncComponentVolumeRelsRejectsInvalidExternalProviders(t *testing.T) {
+	testCases := []struct {
+		name             string
+		externalServices []*dbmodel.TenantServices
+	}{
+		{
+			name: "provider belongs to another tenant",
+			externalServices: []*dbmodel.TenantServices{
+				{ServiceID: syncVolumeProviderComponentID, TenantID: "other-tenant-id"},
+			},
+		},
+		{
+			name:             "provider does not exist",
+			externalServices: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceDao := &syncVolumeRelationTenantServiceDao{
+				services:         []*dbmodel.TenantServices{{ServiceID: syncVolumeConsumerComponentID}},
+				externalServices: tc.externalServices,
+			}
+			volumeDao := &syncVolumeRelationVolumeDao{
+				providerVolume: &dbmodel.TenantServiceVolume{
+					ServiceID:  syncVolumeProviderComponentID,
+					VolumeName: syncVolumeName,
+					VolumeType: dbmodel.ConfigFileVolumeType.String(),
+				},
+			}
+			mountDao := &syncVolumeRelationMountDao{}
+			setSyncVolumeRelationTestManager(t, syncVolumeRelationTestManager{
+				serviceDao:       serviceDao,
+				volumeDao:        volumeDao,
+				mountRelationDao: mountDao,
+			})
+
+			err := (&ServiceAction{}).SyncComponentVolumeRels(nil, &dbmodel.Application{
+				AppID:    syncVolumeAppID,
+				TenantID: syncVolumeTenantID,
+			}, []*apimodel.Component{syncVolumeRelationTestComponent()})
+			if err != nil {
+				t.Fatalf("sync component volume relations: %v", err)
+			}
+
+			if !containsSyncVolumeString(serviceDao.requestedServiceIDs, syncVolumeProviderComponentID) {
+				t.Fatalf("expected external provider lookup to include %q, got %v", syncVolumeProviderComponentID, serviceDao.requestedServiceIDs)
+			}
+			if containsSyncVolumeString(volumeDao.requestedIDs, syncVolumeProviderComponentID) {
+				t.Fatalf("expected invalid external provider %q to be excluded from volume lookup, got %v", syncVolumeProviderComponentID, volumeDao.requestedIDs)
+			}
+			if len(mountDao.createdRelations) != 0 {
+				t.Fatalf("expected no relation for invalid external provider, got %#v", mountDao.createdRelations)
+			}
+		})
+	}
+}
+
+// capability_id: rainbond.app-upgrade.cross-app-config-mount
+func TestSyncComponentVolumeRelsReturnsExternalProviderLookupError(t *testing.T) {
+	expectedErr := errors.New("external provider lookup failed")
+	serviceDao := &syncVolumeRelationTenantServiceDao{
+		services:            []*dbmodel.TenantServices{{ServiceID: syncVolumeConsumerComponentID}},
+		externalServicesErr: expectedErr,
+	}
+	setSyncVolumeRelationTestManager(t, syncVolumeRelationTestManager{serviceDao: serviceDao})
+
+	err := (&ServiceAction{}).SyncComponentVolumeRels(nil, &dbmodel.Application{
+		AppID:    syncVolumeAppID,
+		TenantID: syncVolumeTenantID,
+	}, []*apimodel.Component{syncVolumeRelationTestComponent()})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected external provider lookup error %v, got %v", expectedErr, err)
+	}
+}
+
+func containsSyncVolumeString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -468,6 +468,32 @@
       "status": "active"
     },
     {
+      "id": "rainbond.app-upgrade.cross-app-config-mount",
+      "title": "Preserve cross-application config-file mounts during upgrade",
+      "title_zh": "Preserve cross-application config-file mounts during upgrade",
+      "interface_type": "handler_method",
+      "interface": "api/handler.ServiceAction.SyncComponentVolumeRels",
+      "code_paths": [
+        "api/handler/service.go"
+      ],
+      "tests": [
+        {
+          "path": "api/handler/service_sync_volume_relations_test.go",
+          "selector": "TestSyncComponentVolumeRelsPreservesCrossApplicationConfigFileMount"
+        },
+        {
+          "path": "api/handler/service_sync_volume_relations_test.go",
+          "selector": "TestSyncComponentVolumeRelsRejectsInvalidExternalProviders"
+        },
+        {
+          "path": "api/handler/service_sync_volume_relations_test.go",
+          "selector": "TestSyncComponentVolumeRelsReturnsExternalProviderLookupError"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "rainbond.application.check-port-k8s-service-name-duplicate",
       "title": "Reject duplicate Kubernetes service names across app ports",
       "title_zh": "\u6821\u9a8c\u5e94\u7528\u7aef\u53e3 Kubernetes Service \u540d\u79f0\u91cd\u590d",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -30,6 +30,7 @@
 | rainbond.app-restore.service-id-lookup | 从恢复后的服务映射中反查原始服务 ID | active | regression | builder/exector.BackupAPPRestore.getOldServiceID | builder/exector/groupapp_restore_test.go::TestGetOldServiceID |
 | rainbond.app-restore.snapshot-relationship-rewrite | 应用恢复时重写服务依赖关系 | active | regression | builder/exector.BackupAPPRestore.modify | builder/exector/groupapp_restore_test.go::TestModify |
 | rainbond.app-restore.unzip-all-data | 在恢复时解压完整备份数据包 | active | regression | builder/exector.BackupAPPRestore | builder/exector/groupapp_restore_test.go::TestUnzipAllDataFile |
+| rainbond.app-upgrade.cross-app-config-mount | Preserve cross-application config-file mounts during upgrade | active | regression | api/handler.ServiceAction.SyncComponentVolumeRels | api/handler/service_sync_volume_relations_test.go::TestSyncComponentVolumeRelsPreservesCrossApplicationConfigFileMount<br>api/handler/service_sync_volume_relations_test.go::TestSyncComponentVolumeRelsRejectsInvalidExternalProviders<br>api/handler/service_sync_volume_relations_test.go::TestSyncComponentVolumeRelsReturnsExternalProviderLookupError |
 | rainbond.application.check-port-k8s-service-name-duplicate | 校验应用端口 Kubernetes Service 名称重复 | active | regression | api/handler.ApplicationAction.checkPorts | api/handler/application_handler_test.go::TestApplicationActionCheckPortsRejectsDuplicateK8sServiceName |
 | rainbond.build.select-builder-by-language | 按源码语言和构建类型选择构建器 | active | regression | builder/build.GetBuildByType | builder/build/build_type_matrix_test.go::TestGetBuildByType_SourceBuildLanguageMatrix |
 | rainbond.builder.dynamic-mirror-config | Dynamic mirror config defaults and env overrides | active | unit | builder/mirror.LoadConfig | builder/mirror/config_test.go::TestLoadConfigDefaults |
@@ -730,6 +731,16 @@
 - 业务入口: `builder/exector.BackupAPPRestore`
 - 代码路径: `builder/exector/groupapp_restore.go`
 - 测试路径: `builder/exector/groupapp_restore_test.go::TestUnzipAllDataFile`
+
+### Preserve cross-application config-file mounts during upgrade
+
+- Capability ID: `rainbond.app-upgrade.cross-app-config-mount`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `handler_method`
+- 业务入口: `api/handler.ServiceAction.SyncComponentVolumeRels`
+- 代码路径: `api/handler/service.go`
+- 测试路径: `api/handler/service_sync_volume_relations_test.go::TestSyncComponentVolumeRelsPreservesCrossApplicationConfigFileMount`, `api/handler/service_sync_volume_relations_test.go::TestSyncComponentVolumeRelsRejectsInvalidExternalProviders`, `api/handler/service_sync_volume_relations_test.go::TestSyncComponentVolumeRelsReturnsExternalProviderLookupError`
 
 ### 校验应用端口 Kubernetes Service 名称重复
 

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -93,12 +93,14 @@
 | rainbond.compose.parse-warnings | 解析 docker compose 并返回降级告警 | active | regression | builder/parser.CreateDockerComposeParse.Parse | builder/parser/docker_compose_warnings_test.go::TestDockerComposeParseWithWarnings |
 | rainbond.compose.preserve-volume-source-path | Preserve docker compose volume source paths | active | regression | builder/parser/compose.loadV3Volumes | builder/parser/compose/version_detect_test.go::TestLoadV3VolumesPreservesSourcePathUnderscores |
 | rainbond.compose.yaml-anchor-support | 支持 docker compose 中的 YAML anchors | active | regression | builder/parser.CreateDockerComposeParse.Parse | builder/parser/docker_compose_warnings_test.go::TestDockerComposeParseWithYAMLAnchors |
+| rainbond.config-file.dependent-configmap-ownership | 依赖配置文件保持提供方所有权 | active | regression | worker/appm/volume.ConfigFileVolume.CreateDependVolume | worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeUsesProviderConfigMap<br>worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForVMUsesProviderIdentity<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapLeavesExistingDependencyConfigMapToProvider<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapCreatesMissingDependencyConfigMapForProvider<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotDeleteProviderDependency<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapReclaimsLegacyProviderConfigMap<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotAdoptForeignCollision |
 | rainbond.config-file.k8s-volume-name-safe | Keep config-file Kubernetes volume names DNS-safe | active | regression | worker/appm/volume.ConfigFileVolume.CreateVolume | worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateVolumeForDeploymentUsesK8sSafeVolumeName<br>worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForDeploymentUsesK8sSafeVolumeName |
 | rainbond.config-files.detect | 识别源码目录中的 npm 和 yarn 配置文件 | active | regression | builder/parser/code.DetectConfigFiles | builder/parser/code/config_files_test.go::TestDetectConfigFiles_Npmrc<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_YarnrcClassic<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_YarnrcYml<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_Multiple<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_None |
 | rainbond.config-files.has-any | 检测源码中是否存在包管理器配置文件 | active | regression | builder/parser/code.ConfigFiles.HasAnyConfigFile | builder/parser/code/config_files_test.go::TestConfigFiles_HasAnyConfigFile |
 | rainbond.config-files.read-npmrc | 读取源码中的 npmrc 内容 | active | regression | builder/parser/code.ConfigFiles.GetNpmrcContent | builder/parser/code/config_files_test.go::TestConfigFiles_GetNpmrcContent |
 | rainbond.config-files.read-yarnrc | 读取源码中的 yarnrc 内容 | active | regression | builder/parser/code.ConfigFiles.GetYarnrcContent | builder/parser/code/config_files_test.go::TestConfigFiles_GetYarnrcContent |
 | rainbond.config-files.resolve-relevant-file | 为包管理器选择相关配置文件 | active | regression | builder/parser/code.ConfigFiles.GetRelevantConfigFile | builder/parser/code/config_files_test.go::TestConfigFiles_GetRelevantConfigFile |
+| rainbond.dockerfile-build.proxy-env-inheritance | Dockerfile BuildKit proxy environment inheritance | active | regression | builder/build.buildKitProxyEnvVars | builder/build/dockerfile_build_test.go::TestBuildKitProxyEnvVars |
 | rainbond.dockerfile-build.registry-mirror-toml | Render BuildKit TOML with optional registry mirrors | active | regression | builder/sources.buildKitTomlContent | builder/sources/buildkit_toml_test.go::TestBuildKitTomlContent<br>builder/sources/buildkit_toml_test.go::TestBuildKitTomlContentLegacyEquivalence |
 | rainbond.dockerfile.line-info | 跟踪 Dockerfile AST 的行号信息 | active | regression | util/dockerfile/parser.Parse | util/dockerfile/parser/parser_test.go::TestLineInformation |
 | rainbond.dockerfile.parse-fixtures | 将标准 Dockerfile 示例解析为稳定 AST | active | regression | util/dockerfile/parser.Parse | util/dockerfile/parser/parser_test.go::TestTestData |
@@ -371,6 +373,8 @@
 | rainbond.vm-hotplug.data-volume-capacity-gi | 使用 Gi 容量创建虚拟机热插数据卷 | active | regression | api/handler.buildVMHotplugDataVolumeObject | api/handler/service_vm_hotplug_test.go::TestBuildVMHotplugDataVolumeObjectUsesGiCapacity |
 | rainbond.vm-hotplug.remove-volume-running-vm | 删除存储时热移除运行中虚拟机的数据磁盘 | active | regression | api/handler.ServiceAction.VolumnVar | api/handler/service_vm_hotplug_test.go::TestHotunplugVMDataDiskRemovesVolumeFromRunningVM<br>api/handler/service_vm_hotplug_test.go::TestHotunplugVMDataDiskDeletesBackingDataVolumeAndPVC<br>api/handler/service_vm_hotplug_test.go::TestVolumnVarDeleteHotunplugsRunningVMDataDisk |
 | rainbond.vm-import.registry-datavolume | 通过 registry DataVolume 导入虚拟机系统盘 | active | regression | worker/appm/volume.BuildVMDataVolumeTemplate | worker/appm/volume/vm_import_test.go::TestBuildVMRegistryImportDataVolumeTemplate<br>worker/appm/volume/vm_import_test.go::TestBuildVMRegistryImportDataVolumeTemplateAddsDockerSchemeWhenMissing<br>worker/appm/volume/vm_import_test.go::TestBuildVMRegistryImportDataVolumeTemplatePrefixesInternalRegistryForShortImage |
+| rainbond.vm-import.registry-reference-validation | Reject malformed VM registry image references | active | regression | worker/appm/volume.normalizeVMRegistryImportURL | worker/appm/volume/vm_import_test.go::TestNormalizeVMRegistryImportURLRejectsInvalidReference |
+| rainbond.vm-import.validation-aborts-vm-definition | Abort VM definition for invalid registry imports | active | regression | worker/appm/conversion.createVolumes | worker/appm/conversion/version_vm_import_test.go::TestCreateVolumesRejectsInvalidVMRegistryImport |
 | rainbond.vm-live-update.capability-requires-installer-media-removal | 初始化安装光盘未删除时屏蔽热更新能力 | active | regression | api/handler.ServiceAction.GetVMLiveUpdateCapability | api/handler/service_vm_live_update_test.go::TestGetVMLiveUpdateCapabilityRejectsWhenInstallerMediaStillAttached |
 | rainbond.vm-live-update.capability-requires-migration-target | 无可用迁移目标节点时屏蔽热更新能力 | active | regression | api/handler.ServiceAction.GetVMLiveUpdateCapability | api/handler/service_vm_live_update_test.go::TestGetVMLiveUpdateCapabilityRejectsWhenNoMigrationTargetNode |
 | rainbond.vm-live-update.cpu-memory-combined-rejected | 拒绝运行中虚拟机同时热更新 CPU 和内存 | active | regression | api/handler.ServiceAction.applyVMLiveUpdateIfPossible | api/handler/service_vm_live_update_test.go::TestServiceVerticalVMLiveUpdateRejectsCombinedCPUAndMemoryChange |
@@ -1357,6 +1361,16 @@
 - 代码路径: `builder/parser/docker_compose.go`
 - 测试路径: `builder/parser/docker_compose_warnings_test.go::TestDockerComposeParseWithYAMLAnchors`
 
+### 依赖配置文件保持提供方所有权
+
+- Capability ID: `rainbond.config-file.dependent-configmap-ownership`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/volume.ConfigFileVolume.CreateDependVolume`
+- 代码路径: `worker/appm/volume/config-file.go`, `worker/appm/controller/upgrade.go`, `worker/appm/types/v1/labels.go`
+- 测试路径: `worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeUsesProviderConfigMap`, `worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForVMUsesProviderIdentity`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapLeavesExistingDependencyConfigMapToProvider`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapCreatesMissingDependencyConfigMapForProvider`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotDeleteProviderDependency`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapReclaimsLegacyProviderConfigMap`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotAdoptForeignCollision`
+
 ### Keep config-file Kubernetes volume names DNS-safe
 
 - Capability ID: `rainbond.config-file.k8s-volume-name-safe`
@@ -1416,6 +1430,16 @@
 - 业务入口: `builder/parser/code.ConfigFiles.GetRelevantConfigFile`
 - 代码路径: `builder/parser/code/config_files.go`
 - 测试路径: `builder/parser/code/config_files_test.go::TestConfigFiles_GetRelevantConfigFile`
+
+### Dockerfile BuildKit proxy environment inheritance
+
+- Capability ID: `rainbond.dockerfile-build.proxy-env-inheritance`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `builder/build.buildKitProxyEnvVars`
+- 代码路径: `builder/build/dockerfile_build.go`
+- 测试路径: `builder/build/dockerfile_build_test.go::TestBuildKitProxyEnvVars`
 
 ### Render BuildKit TOML with optional registry mirrors
 
@@ -4136,6 +4160,26 @@
 - 业务入口: `worker/appm/volume.BuildVMDataVolumeTemplate`
 - 代码路径: `worker/appm/volume/vm_import.go`
 - 测试路径: `worker/appm/volume/vm_import_test.go::TestBuildVMRegistryImportDataVolumeTemplate`, `worker/appm/volume/vm_import_test.go::TestBuildVMRegistryImportDataVolumeTemplateAddsDockerSchemeWhenMissing`, `worker/appm/volume/vm_import_test.go::TestBuildVMRegistryImportDataVolumeTemplatePrefixesInternalRegistryForShortImage`
+
+### Reject malformed VM registry image references
+
+- Capability ID: `rainbond.vm-import.registry-reference-validation`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/volume.normalizeVMRegistryImportURL`
+- 代码路径: `worker/appm/volume/vm_import.go`, `worker/appm/volume/share-file.go`
+- 测试路径: `worker/appm/volume/vm_import_test.go::TestNormalizeVMRegistryImportURLRejectsInvalidReference`
+
+### Abort VM definition for invalid registry imports
+
+- Capability ID: `rainbond.vm-import.validation-aborts-vm-definition`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/conversion.createVolumes`
+- 代码路径: `worker/appm/conversion/version.go`, `worker/appm/volume/share-file.go`, `worker/appm/volume/vm_import.go`
+- 测试路径: `worker/appm/conversion/version_vm_import_test.go::TestCreateVolumesRejectsInvalidVMRegistryImport`
 
 ### 初始化安装光盘未删除时屏蔽热更新能力
 


### PR DESCRIPTION
## Summary

- include same-tenant external volume providers when rebuilding application upgrade volume relations
- preserve cross-application shared config-file mounts after an application-model upgrade
- reject cross-tenant and missing provider component IDs
- add managed regression coverage for success and safety boundaries

## Verification

- go test ./api/handler -count=1
- go build ./...
- go vet ./...
- make check
- cross-repository API compatibility check: no route, request, or response changes

## Related

- Offline local upgrade detail fix: https://github.com/goodrain/rainbond-console/pull/2110