### PR TITLE
fix: repair shared config file mounts

### DIFF
--- a/api/handler/service.go
+++ b/api/handler/service.go
@@ -2627,7 +2627,7 @@ func (s *ServiceAction) VolumeDependency(tsr *dbmodel.TenantServiceMountRelation
 		}
 	case "delete":
 		if tsr.VolumeName != "" {
-			if err := db.GetManager().TenantServiceMountRelationDao().DElTenantServiceMountRelationByServiceAndName(tsr.ServiceID, tsr.VolumeName); err != nil {
+			if err := db.GetManager().TenantServiceMountRelationDao().DeleteTenantServiceMountRelation(tsr.ServiceID, tsr.DependServiceID, tsr.VolumeName); err != nil {
 				return util.CreateAPIHandleErrorFromDBError("delete mount relation", err)
 			}
 		} else {

--- a/api/handler/service_volume_dependency_test.go
+++ b/api/handler/service_volume_dependency_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/goodrain/rainbond/db"
+	dbdao "github.com/goodrain/rainbond/db/dao"
+	dbmodel "github.com/goodrain/rainbond/db/model"
+)
+
+type volumeDependencyDeleteTestManager struct {
+	db.Manager
+	mountRelationDao dbdao.TenantServiceMountRelationDao
+}
+
+func (m volumeDependencyDeleteTestManager) TenantServiceMountRelationDao() dbdao.TenantServiceMountRelationDao {
+	return m.mountRelationDao
+}
+
+type preciseVolumeDependencyDeleteDao struct {
+	dbdao.TenantServiceMountRelationDao
+	serviceID       string
+	dependServiceID string
+	volumeName      string
+}
+
+func (d *preciseVolumeDependencyDeleteDao) DeleteTenantServiceMountRelation(serviceID, dependServiceID, volumeName string) error {
+	d.serviceID = serviceID
+	d.dependServiceID = dependServiceID
+	d.volumeName = volumeName
+	return nil
+}
+
+// capability_id: rainbond.volume-dependency.precise-delete
+func TestVolumeDependencyDeleteUsesConsumerProviderAndVolumeName(t *testing.T) {
+	dao := &preciseVolumeDependencyDeleteDao{}
+	originalManager := db.GetManager()
+	db.SetTestManager(volumeDependencyDeleteTestManager{mountRelationDao: dao})
+	t.Cleanup(func() { db.SetTestManager(originalManager) })
+
+	relation := &dbmodel.TenantServiceMountRelation{
+		ServiceID:       "consumer-service",
+		DependServiceID: "provider-service",
+		VolumeName:      "shared-config",
+	}
+	if apiErr := (&ServiceAction{}).VolumeDependency(relation, "delete"); apiErr != nil {
+		t.Fatalf("delete volume dependency: %v", apiErr)
+	}
+	if dao.serviceID != relation.ServiceID || dao.dependServiceID != relation.DependServiceID || dao.volumeName != relation.VolumeName {
+		t.Fatalf("expected exact delete (%q, %q, %q), got (%q, %q, %q)",
+			relation.ServiceID, relation.DependServiceID, relation.VolumeName,
+			dao.serviceID, dao.dependServiceID, dao.volumeName)
+	}
+}

--- a/db/dao/dao.go
+++ b/db/dao/dao.go
@@ -343,7 +343,7 @@ type TenantServiceMountRelationDao interface {
 	Dao
 	GetTenantServiceMountRelationsByService(serviceID string) ([]*model.TenantServiceMountRelation, error)
 	GetTenantServiceMountRelationsByDepServiceAndVolumeName(serviceID, volumeName string) ([]*model.TenantServiceMountRelation, error)
-	DElTenantServiceMountRelationByServiceAndName(serviceID, mntDir string) error
+	DeleteTenantServiceMountRelation(serviceID, dependServiceID, volumeName string) error
 	DELTenantServiceMountRelationByServiceID(serviceID string) error
 	DElTenantServiceMountRelationByDepService(serviceID, depServiceID string) error
 	DeleteByComponentIDs(componentIDs []string) error

--- a/db/dao/dao_mock.go
+++ b/db/dao/dao_mock.go
@@ -2761,16 +2761,16 @@ func (mr *MockTenantServiceMountRelationDaoMockRecorder) GetTenantServiceMountRe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTenantServiceMountRelationsByDepServiceAndVolumeName", reflect.TypeOf((*MockTenantServiceMountRelationDao)(nil).GetTenantServiceMountRelationsByDepServiceAndVolumeName), serviceID, volumeName)
 }
 
-// DElTenantServiceMountRelationByServiceAndName mocks base method
-func (m *MockTenantServiceMountRelationDao) DElTenantServiceMountRelationByServiceAndName(serviceID, mntDir string) error {
-	ret := m.ctrl.Call(m, "DElTenantServiceMountRelationByServiceAndName", serviceID, mntDir)
+// DeleteTenantServiceMountRelation mocks base method
+func (m *MockTenantServiceMountRelationDao) DeleteTenantServiceMountRelation(serviceID, dependServiceID, volumeName string) error {
+	ret := m.ctrl.Call(m, "DeleteTenantServiceMountRelation", serviceID, dependServiceID, volumeName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DElTenantServiceMountRelationByServiceAndName indicates an expected call of DElTenantServiceMountRelationByServiceAndName
-func (mr *MockTenantServiceMountRelationDaoMockRecorder) DElTenantServiceMountRelationByServiceAndName(serviceID, mntDir interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DElTenantServiceMountRelationByServiceAndName", reflect.TypeOf((*MockTenantServiceMountRelationDao)(nil).DElTenantServiceMountRelationByServiceAndName), serviceID, mntDir)
+// DeleteTenantServiceMountRelation indicates an expected call of DeleteTenantServiceMountRelation
+func (mr *MockTenantServiceMountRelationDaoMockRecorder) DeleteTenantServiceMountRelation(serviceID, dependServiceID, volumeName interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTenantServiceMountRelation", reflect.TypeOf((*MockTenantServiceMountRelationDao)(nil).DeleteTenantServiceMountRelation), serviceID, dependServiceID, volumeName)
 }
 
 // DELTenantServiceMountRelationByServiceID mocks base method

--- a/db/mysql/dao/tenant_service_mount_relation_test.go
+++ b/db/mysql/dao/tenant_service_mount_relation_test.go
@@ -1,0 +1,53 @@
+package dao
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/goodrain/rainbond/db/model"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+// capability_id: rainbond.volume-dependency.precise-delete
+func TestTenantServiceMountRelationDaoDeletesOnlyRequestedProviderVolume(t *testing.T) {
+	database, err := gorm.Open("sqlite3", filepath.Join(t.TempDir(), "mount-relations.db"))
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	defer database.Close()
+	database.LogMode(false)
+	if err := database.AutoMigrate(&model.TenantServiceMountRelation{}).Error; err != nil {
+		t.Fatalf("migrate mount relation table: %v", err)
+	}
+
+	dao := &TenantServiceMountRelationDaoImpl{DB: database}
+	const (
+		consumerID = "consumer-service"
+		volumeName = "shared-config"
+		providerA  = "provider-a"
+		providerB  = "provider-b"
+	)
+	for _, providerID := range []string{providerA, providerB} {
+		if err := dao.AddModel(&model.TenantServiceMountRelation{
+			ServiceID:       consumerID,
+			DependServiceID: providerID,
+			VolumeName:      volumeName,
+			VolumePath:      "/etc/config/" + providerID,
+			VolumeType:      model.ConfigFileVolumeType.String(),
+		}); err != nil {
+			t.Fatalf("add mount relation for %s: %v", providerID, err)
+		}
+	}
+
+	if err := dao.DeleteTenantServiceMountRelation(consumerID, providerA, volumeName); err != nil {
+		t.Fatalf("delete provider A mount relation: %v", err)
+	}
+	relations, err := dao.GetTenantServiceMountRelationsByService(consumerID)
+	if err != nil {
+		t.Fatalf("list remaining mount relations: %v", err)
+	}
+	if len(relations) != 1 || relations[0].DependServiceID != providerB {
+		t.Fatalf("expected only provider B relation to remain, got %#v", relations)
+	}
+}

--- a/db/mysql/dao/tenants.go
+++ b/db/mysql/dao/tenants.go
@@ -1288,16 +1288,15 @@ func (t *TenantServiceMountRelationDaoImpl) UpdateModel(mo model.Interface) erro
 	return nil
 }
 
-// DElTenantServiceMountRelationByServiceAndName DElTenantServiceMountRelationByServiceAndName
-func (t *TenantServiceMountRelationDaoImpl) DElTenantServiceMountRelationByServiceAndName(serviceID, name string) error {
+// DeleteTenantServiceMountRelation deletes one exact provider volume relation.
+func (t *TenantServiceMountRelationDaoImpl) DeleteTenantServiceMountRelation(serviceID, dependServiceID, volumeName string) error {
 	var relation model.TenantServiceMountRelation
-	if err := t.DB.Where("service_id=? and volume_name=? ", serviceID, name).Find(&relation).Error; err != nil {
+	query := t.DB.Where("service_id=? and dep_service_id=? and volume_name=?", serviceID, dependServiceID, volumeName)
+	if err := query.Find(&relation).Error; err != nil {
 		return err
 	}
-	if err := t.DB.Where("service_id=? and volume_name=? ", serviceID, name).Delete(&relation).Error; err != nil {
-		return err
-	}
-	return nil
+	return t.DB.Where("service_id=? and dep_service_id=? and volume_name=?", serviceID, dependServiceID, volumeName).
+		Delete(&relation).Error
 }
 
 // DElTenantServiceMountRelationByDepService del mount relation

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -1708,6 +1708,45 @@
       "status": "active"
     },
     {
+      "id": "rainbond.config-file.dependent-source-key",
+      "title": "Dependent config files use provider source keys",
+      "title_zh": "\u4f9d\u8d56\u914d\u7f6e\u6587\u4ef6\u4f7f\u7528\u63d0\u4f9b\u65b9\u6e90\u6587\u4ef6\u952e",
+      "interface_type": "workflow",
+      "interface": "worker/appm/volume.ConfigFileVolume.CreateDependVolume",
+      "code_paths": [
+        "worker/appm/volume/config-file.go",
+        "worker/appm/controller/upgrade.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/volume/share_file_vm_test.go",
+          "selector": "TestConfigFileVolumeCreateDependVolumeUsesProviderFileKey"
+        },
+        {
+          "path": "worker/appm/volume/share_file_vm_test.go",
+          "selector": "TestConfigFileVolumeCreateDependVolumeForVMUsesProviderFileKey"
+        },
+        {
+          "path": "worker/appm/controller/upgrade_test.go",
+          "selector": "TestUpgradeConfigMapMigratesOnlyLegacyDependentSourceKey"
+        },
+        {
+          "path": "worker/appm/controller/upgrade_test.go",
+          "selector": "TestUpgradeConfigMapMigratesOnlyKnownLegacyConsumerConfigMap"
+        },
+        {
+          "path": "worker/appm/controller/upgrade_test.go",
+          "selector": "TestUpgradeConfigMapRetriesDependentMigrationConflict"
+        },
+        {
+          "path": "worker/appm/controller/upgrade_test.go",
+          "selector": "TestUpgradeConfigMapHandlesDependentCreateRace"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "rainbond.config-file.k8s-volume-name-safe",
       "title": "Keep config-file Kubernetes volume names DNS-safe",
       "title_zh": "Keep config-file Kubernetes volume names DNS-safe",
@@ -7611,6 +7650,30 @@
         {
           "path": "db/mysql/dao/tenant_service_volume_vm_test.go",
           "selector": "TestTenantServiceVolumeDaoAddModelAllowsDuplicateVMDevicePath"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.volume-dependency.precise-delete",
+      "title": "Delete only the requested provider volume relation",
+      "title_zh": "\u4ec5\u5220\u9664\u6307\u5b9a\u63d0\u4f9b\u65b9\u7684\u6302\u8f7d\u5173\u7cfb",
+      "interface_type": "handler_method",
+      "interface": "api/handler.ServiceAction.VolumeDependency",
+      "code_paths": [
+        "api/handler/service.go",
+        "db/dao/dao.go",
+        "db/mysql/dao/tenants.go"
+      ],
+      "tests": [
+        {
+          "path": "api/handler/service_volume_dependency_test.go",
+          "selector": "TestVolumeDependencyDeleteUsesConsumerProviderAndVolumeName"
+        },
+        {
+          "path": "db/mysql/dao/tenant_service_mount_relation_test.go",
+          "selector": "TestTenantServiceMountRelationDaoDeletesOnlyRequestedProviderVolume"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -95,6 +95,7 @@
 | rainbond.compose.preserve-volume-source-path | Preserve docker compose volume source paths | active | regression | builder/parser/compose.loadV3Volumes | builder/parser/compose/version_detect_test.go::TestLoadV3VolumesPreservesSourcePathUnderscores |
 | rainbond.compose.yaml-anchor-support | 支持 docker compose 中的 YAML anchors | active | regression | builder/parser.CreateDockerComposeParse.Parse | builder/parser/docker_compose_warnings_test.go::TestDockerComposeParseWithYAMLAnchors |
 | rainbond.config-file.dependent-configmap-ownership | 依赖配置文件保持提供方所有权 | active | regression | worker/appm/volume.ConfigFileVolume.CreateDependVolume | worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeUsesProviderConfigMap<br>worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForVMUsesProviderIdentity<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapLeavesExistingDependencyConfigMapToProvider<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapCreatesMissingDependencyConfigMapForProvider<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotDeleteProviderDependency<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapReclaimsLegacyProviderConfigMap<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotAdoptForeignCollision |
+| rainbond.config-file.dependent-source-key | 依赖配置文件使用提供方源文件键 | active | regression | worker/appm/volume.ConfigFileVolume.CreateDependVolume | worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeUsesProviderFileKey<br>worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForVMUsesProviderFileKey<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapMigratesOnlyLegacyDependentSourceKey<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapMigratesOnlyKnownLegacyConsumerConfigMap<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapRetriesDependentMigrationConflict<br>worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapHandlesDependentCreateRace |
 | rainbond.config-file.k8s-volume-name-safe | Keep config-file Kubernetes volume names DNS-safe | active | regression | worker/appm/volume.ConfigFileVolume.CreateVolume | worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateVolumeForDeploymentUsesK8sSafeVolumeName<br>worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForDeploymentUsesK8sSafeVolumeName |
 | rainbond.config-files.detect | 识别源码目录中的 npm 和 yarn 配置文件 | active | regression | builder/parser/code.DetectConfigFiles | builder/parser/code/config_files_test.go::TestDetectConfigFiles_Npmrc<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_YarnrcClassic<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_YarnrcYml<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_Multiple<br>builder/parser/code/config_files_test.go::TestDetectConfigFiles_None |
 | rainbond.config-files.has-any | 检测源码中是否存在包管理器配置文件 | active | regression | builder/parser/code.ConfigFiles.HasAnyConfigFile | builder/parser/code/config_files_test.go::TestConfigFiles_HasAnyConfigFile |
@@ -406,6 +407,7 @@
 | rainbond.vm-volume-selected-storage-class | 为 VM 数据卷保留所选存储类 | active | regression | worker/appm/volume.ShareFileVolume.CreateVolume | worker/appm/volume/share_file_vm_test.go::TestNewVolumeManagerUsesSelectedStorageClassForVMDisks |
 | rainbond.vm-volume-vm-file-backward-compatible | 旧版 vm-file 虚机卷继续回退到 local-path | active | regression | worker/appm/volume.ShareFileVolume.CreateVolume | worker/appm/volume/share_file_vm_test.go::TestShareFileVolumeVMStorageClassFallsBackToLocalPathForLegacyVMFile |
 | rainbond.vm-volume.allow-shared-device-paths | 允许 VM 服务在不同数据卷间复用设备路径 | active | regression | db/mysql/dao.TenantServiceVolumeDaoImpl.AddModel | db/mysql/dao/tenant_service_volume_vm_test.go::TestTenantServiceVolumeDaoAddModelAllowsDuplicateVMDevicePath |
+| rainbond.volume-dependency.precise-delete | 仅删除指定提供方的挂载关系 | active | regression | api/handler.ServiceAction.VolumeDependency | api/handler/service_volume_dependency_test.go::TestVolumeDependencyDeleteUsesConsumerProviderAndVolumeName<br>db/mysql/dao/tenant_service_mount_relation_test.go::TestTenantServiceMountRelationDaoDeletesOnlyRequestedProviderVolume |
 | rainbond.volume.keep-non-vm-path-uniqueness | 保持非 VM 服务卷路径唯一性校验 | active | regression | db/mysql/dao.TenantServiceVolumeDaoImpl.AddModel | db/mysql/dao/tenant_service_volume_vm_test.go::TestTenantServiceVolumeDaoAddModelRejectsDuplicatePathForNonVMService |
 | rainbond.watch.error-dispatch | 将 watch 后端错误分发到内部错误通道 | active | regression | util/watch.watchChan.sendError | util/watch/watch_test.go::TestWatchChanSendError |
 | rainbond.watch.error-parse | 将 watch 后端错误转换为 API 错误事件 | active | regression | util/watch.parseError | util/watch/watch_test.go::TestParseError |
@@ -1381,6 +1383,16 @@
 - 业务入口: `worker/appm/volume.ConfigFileVolume.CreateDependVolume`
 - 代码路径: `worker/appm/volume/config-file.go`, `worker/appm/controller/upgrade.go`, `worker/appm/types/v1/labels.go`
 - 测试路径: `worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeUsesProviderConfigMap`, `worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForVMUsesProviderIdentity`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapLeavesExistingDependencyConfigMapToProvider`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapCreatesMissingDependencyConfigMapForProvider`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotDeleteProviderDependency`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapReclaimsLegacyProviderConfigMap`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapDoesNotAdoptForeignCollision`
+
+### 依赖配置文件使用提供方源文件键
+
+- Capability ID: `rainbond.config-file.dependent-source-key`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/volume.ConfigFileVolume.CreateDependVolume`
+- 代码路径: `worker/appm/volume/config-file.go`, `worker/appm/controller/upgrade.go`
+- 测试路径: `worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeUsesProviderFileKey`, `worker/appm/volume/share_file_vm_test.go::TestConfigFileVolumeCreateDependVolumeForVMUsesProviderFileKey`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapMigratesOnlyLegacyDependentSourceKey`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapMigratesOnlyKnownLegacyConsumerConfigMap`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapRetriesDependentMigrationConflict`, `worker/appm/controller/upgrade_test.go::TestUpgradeConfigMapHandlesDependentCreateRace`
 
 ### Keep config-file Kubernetes volume names DNS-safe
 
@@ -4491,6 +4503,16 @@
 - 业务入口: `db/mysql/dao.TenantServiceVolumeDaoImpl.AddModel`
 - 代码路径: `db/mysql/dao/tenants.go`
 - 测试路径: `db/mysql/dao/tenant_service_volume_vm_test.go::TestTenantServiceVolumeDaoAddModelAllowsDuplicateVMDevicePath`
+
+### 仅删除指定提供方的挂载关系
+
+- Capability ID: `rainbond.volume-dependency.precise-delete`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `handler_method`
+- 业务入口: `api/handler.ServiceAction.VolumeDependency`
+- 代码路径: `api/handler/service.go`, `db/dao/dao.go`, `db/mysql/dao/tenants.go`
+- 测试路径: `api/handler/service_volume_dependency_test.go::TestVolumeDependencyDeleteUsesConsumerProviderAndVolumeName`, `db/mysql/dao/tenant_service_mount_relation_test.go::TestTenantServiceMountRelationDaoDeletesOnlyRequestedProviderVolume`
 
 ### 保持非 VM 服务卷路径唯一性校验
 

--- a/worker/appm/controller/upgrade.go
+++ b/worker/appm/controller/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 )
 
 type upgradeController struct {
@@ -104,11 +106,9 @@ func (s *upgradeController) upgradeConfigMap(nowApp *v1.AppService, newapp v1.Ap
 	var errs []error
 	for _, new := range newConfigMaps {
 		if new.Annotations[v1.ConfigFileScopeAnnotation] == v1.ConfigFileScopeDependent {
+			nowConfig := nowConfigMapMaps[new.Name]
 			nowConfigMapMaps[new.Name] = nil
-			_, err := s.manager.client.CoreV1().ConfigMaps(nowApp.GetNamespace()).Get(s.ctx, new.Name, metav1.GetOptions{})
-			if errors.IsNotFound(err) {
-				_, err = s.manager.client.CoreV1().ConfigMaps(nowApp.GetNamespace()).Create(s.ctx, new, metav1.CreateOptions{})
-			}
+			err := s.ensureDependentConfigMap(nowApp.GetNamespace(), nowApp.ServiceID, nowConfig, new)
 			if err != nil {
 				logrus.Errorf("ensure dependency configmap failure %s", err.Error())
 				errs = append(errs, fmt.Errorf("ensure dependency configmap %s failure: %s", new.Name, err.Error()))
@@ -163,6 +163,65 @@ func (s *upgradeController) upgradeConfigMap(nowApp *v1.AppService, newapp v1.Ap
 		}
 	}
 	return stderrors.Join(errs...)
+}
+
+func (s *upgradeController) ensureDependentConfigMap(namespace, consumerID string, nowConfig, desired *corev1.ConfigMap) error {
+	return retry.OnError(retry.DefaultRetry, func(err error) bool {
+		return errors.IsAlreadyExists(err) || errors.IsConflict(err) || errors.IsNotFound(err)
+	}, func() error {
+		existing, err := s.manager.client.CoreV1().ConfigMaps(namespace).Get(s.ctx, desired.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			_, err = s.manager.client.CoreV1().ConfigMaps(namespace).Create(s.ctx, desired.DeepCopy(), metav1.CreateOptions{})
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		if !migrateLegacyDependentConfigMapKey(existing, desired, nowConfig, consumerID) {
+			return nil
+		}
+		_, err = s.manager.client.CoreV1().ConfigMaps(namespace).Update(s.ctx, existing, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func migrateLegacyDependentConfigMapKey(existing, desired, nowConfig *corev1.ConfigMap, consumerID string) bool {
+	if desired.Annotations[v1.ConfigFileScopeAnnotation] != v1.ConfigFileScopeDependent ||
+		len(existing.Data) != 1 || len(desired.Data) != 1 {
+		return false
+	}
+	providerID := desired.Labels["service_id"]
+	if providerID == "" {
+		return false
+	}
+	switch existing.Annotations[v1.ConfigFileScopeAnnotation] {
+	case v1.ConfigFileScopeDependent:
+		if existing.Labels["service_id"] != providerID {
+			return false
+		}
+	case "":
+		if consumerID == "" || providerID == consumerID || existing.Name != desired.Name ||
+			!strings.HasPrefix(existing.Name, "vm-cfg-") || len(existing.Name) != len("vm-cfg-")+16 ||
+			existing.Labels["creator"] != "Rainbond" || existing.Labels["service_id"] != consumerID ||
+			nowConfig == nil || nowConfig.Name != existing.Name || nowConfig.Labels["service_id"] != consumerID {
+			return false
+		}
+	default:
+		return false
+	}
+	var sourceKey string
+	for key := range desired.Data {
+		sourceKey = key
+	}
+	if _, ok := existing.Data[sourceKey]; ok {
+		return false
+	}
+	var legacyValue string
+	for _, value := range existing.Data {
+		legacyValue = value
+	}
+	existing.Data[sourceKey] = legacyValue
+	return true
 }
 
 func canAdoptConfigMap(existing, desired *corev1.ConfigMap) bool {

--- a/worker/appm/controller/upgrade_test.go
+++ b/worker/appm/controller/upgrade_test.go
@@ -9,8 +9,10 @@ import (
 
 	appmtypes "github.com/goodrain/rainbond/worker/appm/types/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -183,6 +185,216 @@ func TestUpgradeConfigMapLeavesExistingDependencyConfigMapToProvider(t *testing.
 	}
 	if unchanged.Data["application.yaml"] != "owner=provider\n" {
 		t.Fatalf("expected consumer upgrade not to update provider configmap, got %#v", unchanged.Data)
+	}
+}
+
+// capability_id: rainbond.config-file.dependent-source-key
+func TestUpgradeConfigMapMigratesOnlyLegacyDependentSourceKey(t *testing.T) {
+	tests := []struct {
+		name                 string
+		existingScope        string
+		wantSourceValue      string
+		wantSourceKeyPresent bool
+	}{
+		{
+			name:                 "legacy dependent key is retained and aliased",
+			existingScope:        appmtypes.ConfigFileScopeDependent,
+			wantSourceValue:      "existing-rendered-content\n",
+			wantSourceKeyPresent: true,
+		},
+		{
+			name:                 "provider owned configmap is not changed by consumer",
+			existingScope:        appmtypes.ConfigFileScopeOwned,
+			wantSourceKeyPresent: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			existing := configMapForTest("vm-cfg-provider")
+			existing.Labels = map[string]string{"creator": "Rainbond", "service_id": "provider-service"}
+			existing.Annotations = map[string]string{appmtypes.ConfigFileScopeAnnotation: tt.existingScope}
+			existing.Data = map[string]string{"test1.conf": "existing-rendered-content\n"}
+			desired := configMapForTest(existing.Name)
+			desired.Labels = map[string]string{"creator": "Rainbond", "service_id": "provider-service"}
+			desired.Annotations = map[string]string{appmtypes.ConfigFileScopeAnnotation: appmtypes.ConfigFileScopeDependent}
+			desired.Data = map[string]string{"nginx.conf": "consumer-rendered-content\n"}
+
+			client := k8sfake.NewSimpleClientset(namespace, existing.DeepCopy())
+			nowApp := newAppWithConfigMaps(namespace)
+			nowApp.ServiceID = "consumer-service"
+			newApp := newAppWithConfigMaps(namespace, desired)
+			newApp.ServiceID = "consumer-service"
+			controller := &upgradeController{manager: &Manager{client: client}, ctx: context.Background()}
+			if err := controller.upgradeConfigMap(nowApp, *newApp); err != nil {
+				t.Fatalf("migrate dependent configmap: %v", err)
+			}
+			updated, err := client.CoreV1().ConfigMaps("default").Get(context.Background(), existing.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get dependent configmap: %v", err)
+			}
+			if updated.Data["test1.conf"] != "existing-rendered-content\n" {
+				t.Fatalf("expected legacy key content to remain unchanged, got %#v", updated.Data)
+			}
+			sourceValue, sourceKeyPresent := updated.Data["nginx.conf"]
+			if sourceKeyPresent != tt.wantSourceKeyPresent || sourceValue != tt.wantSourceValue {
+				t.Fatalf("expected source key present=%v value=%q, got data=%#v",
+					tt.wantSourceKeyPresent, tt.wantSourceValue, updated.Data)
+			}
+			if sourceValue == desired.Data["nginx.conf"] {
+				t.Fatalf("expected consumer-rendered content not to overwrite provider configmap, got %#v", updated.Data)
+			}
+		})
+	}
+}
+
+// capability_id: rainbond.config-file.dependent-source-key
+func TestUpgradeConfigMapMigratesOnlyKnownLegacyConsumerConfigMap(t *testing.T) {
+	tests := []struct {
+		name                 string
+		creator              string
+		existingServiceID    string
+		knownByCurrentApp    bool
+		wantSourceKeyPresent bool
+	}{
+		{
+			name:                 "pre annotation consumer configmap",
+			creator:              "Rainbond",
+			existingServiceID:    "consumer-service",
+			knownByCurrentApp:    true,
+			wantSourceKeyPresent: true,
+		},
+		{
+			name:              "provider owned configmap without annotation",
+			creator:           "Rainbond",
+			existingServiceID: "provider-service",
+			knownByCurrentApp: true,
+		},
+		{
+			name:              "foreign configmap with consumer label",
+			creator:           "external",
+			existingServiceID: "consumer-service",
+			knownByCurrentApp: true,
+		},
+		{
+			name:              "untracked configmap with consumer label",
+			creator:           "Rainbond",
+			existingServiceID: "consumer-service",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			existing := configMapForTest("vm-cfg-0123456789abcdef")
+			existing.Labels = map[string]string{"creator": tt.creator, "service_id": tt.existingServiceID}
+			existing.Annotations = nil
+			existing.Data = map[string]string{"test1.conf": "legacy-existing-content\n"}
+			desired := configMapForTest(existing.Name)
+			desired.Labels = map[string]string{"creator": "Rainbond", "service_id": "provider-service"}
+			desired.Annotations = map[string]string{appmtypes.ConfigFileScopeAnnotation: appmtypes.ConfigFileScopeDependent}
+			desired.Data = map[string]string{"nginx.conf": "consumer-rendered-content\n"}
+
+			client := k8sfake.NewSimpleClientset(namespace, existing.DeepCopy())
+			nowApp := newAppWithConfigMaps(namespace)
+			nowApp.ServiceID = "consumer-service"
+			if tt.knownByCurrentApp {
+				nowApp.SetConfigMap(existing.DeepCopy())
+			}
+			newApp := newAppWithConfigMaps(namespace, desired)
+			newApp.ServiceID = "consumer-service"
+			controller := &upgradeController{manager: &Manager{client: client}, ctx: context.Background()}
+			if err := controller.upgradeConfigMap(nowApp, *newApp); err != nil {
+				t.Fatalf("reconcile legacy configmap: %v", err)
+			}
+			updated, err := client.CoreV1().ConfigMaps("default").Get(context.Background(), existing.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get legacy configmap: %v", err)
+			}
+			if updated.Data["test1.conf"] != "legacy-existing-content\n" {
+				t.Fatalf("expected legacy content to remain unchanged, got %#v", updated.Data)
+			}
+			sourceValue, sourceKeyPresent := updated.Data["nginx.conf"]
+			if sourceKeyPresent != tt.wantSourceKeyPresent {
+				t.Fatalf("expected source key present=%v, got %#v", tt.wantSourceKeyPresent, updated.Data)
+			}
+			if sourceKeyPresent && sourceValue != "legacy-existing-content\n" {
+				t.Fatalf("expected source key to alias existing content, got %#v", updated.Data)
+			}
+		})
+	}
+}
+
+// capability_id: rainbond.config-file.dependent-source-key
+func TestUpgradeConfigMapRetriesDependentMigrationConflict(t *testing.T) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	existing := configMapForTest("vm-cfg-provider")
+	existing.Labels = map[string]string{"creator": "Rainbond", "service_id": "provider-service"}
+	existing.Annotations = map[string]string{appmtypes.ConfigFileScopeAnnotation: appmtypes.ConfigFileScopeDependent}
+	existing.Data = map[string]string{"test1.conf": "existing-rendered-content\n"}
+	desired := configMapForTest(existing.Name)
+	desired.Labels = map[string]string{"creator": "Rainbond", "service_id": "provider-service"}
+	desired.Annotations = map[string]string{appmtypes.ConfigFileScopeAnnotation: appmtypes.ConfigFileScopeDependent}
+	desired.Data = map[string]string{"nginx.conf": "consumer-rendered-content\n"}
+
+	client := k8sfake.NewSimpleClientset(namespace, existing.DeepCopy())
+	updateAttempts := 0
+	client.PrependReactor("update", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updateAttempts++
+		if updateAttempts == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "configmaps"},
+				existing.Name,
+				errors.New("concurrent migration"),
+			)
+		}
+		return false, nil, nil
+	})
+	controller := &upgradeController{manager: &Manager{client: client}, ctx: context.Background()}
+	if err := controller.upgradeConfigMap(newAppWithConfigMaps(namespace), *newAppWithConfigMaps(namespace, desired)); err != nil {
+		t.Fatalf("migrate dependent configmap after conflict: %v", err)
+	}
+	if updateAttempts != 2 {
+		t.Fatalf("expected two migration update attempts, got %d", updateAttempts)
+	}
+	updated, err := client.CoreV1().ConfigMaps("default").Get(context.Background(), existing.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get migrated configmap: %v", err)
+	}
+	if updated.Data["nginx.conf"] != "existing-rendered-content\n" {
+		t.Fatalf("expected retried migration to preserve existing content, got %#v", updated.Data)
+	}
+}
+
+// capability_id: rainbond.config-file.dependent-source-key
+func TestUpgradeConfigMapHandlesDependentCreateRace(t *testing.T) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	desired := configMapForTest("vm-cfg-provider")
+	desired.Labels = map[string]string{"creator": "Rainbond", "service_id": "provider-service"}
+	desired.Annotations = map[string]string{appmtypes.ConfigFileScopeAnnotation: appmtypes.ConfigFileScopeDependent}
+	desired.Data = map[string]string{"nginx.conf": "provider-content\n"}
+
+	client := k8sfake.NewSimpleClientset(namespace)
+	createAttempts := 0
+	client.PrependReactor("create", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		createAttempts++
+		if createAttempts == 1 {
+			if err := client.Tracker().Add(desired.DeepCopy()); err != nil {
+				t.Fatalf("add concurrently created configmap: %v", err)
+			}
+			return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "configmaps"}, desired.Name)
+		}
+		return false, nil, nil
+	})
+	controller := &upgradeController{manager: &Manager{client: client}, ctx: context.Background()}
+	if err := controller.upgradeConfigMap(newAppWithConfigMaps(namespace), *newAppWithConfigMaps(namespace, desired)); err != nil {
+		t.Fatalf("ensure dependency configmap after create race: %v", err)
+	}
+	if createAttempts != 1 {
+		t.Fatalf("expected one create attempt before observing concurrent result, got %d", createAttempts)
+	}
+	created, err := client.CoreV1().ConfigMaps("default").Get(context.Background(), desired.Name, metav1.GetOptions{})
+	if err != nil || created.Data["nginx.conf"] != "provider-content\n" {
+		t.Fatalf("expected concurrently created provider configmap, got configmap=%#v err=%v", created, err)
 	}
 }
 

--- a/worker/appm/volume/config-file.go
+++ b/worker/appm/volume/config-file.go
@@ -167,7 +167,8 @@ func (v *ConfigFileVolume) CreateDependVolume(define *Define) error {
 		},
 		Data: make(map[string]string),
 	}
-	cmap.Data[path.Base(v.smr.VolumePath)] = util.ParseVariable(cf.FileContent, configs)
+	providerFileName := path.Base(depVol.VolumePath)
+	cmap.Data[providerFileName] = util.ParseVariable(cf.FileContent, configs)
 	v.as.SetConfigMap(cmap)
 	if v.as.GetVirtualMachine() != nil {
 		volumeLabel := stableVMConfigVolumeLabel(v.smr.DependServiceID, v.smr.VolumeName)
@@ -191,14 +192,14 @@ func (v *ConfigFileVolume) CreateDependVolume(define *Define) error {
 		define.AddVMGuestFile(VMGuestFile{
 			VolumeName:  cmap.Name,
 			VolumeLabel: volumeLabel,
-			SourceFile:  path.Base(v.smr.VolumePath),
+			SourceFile:  providerFileName,
 			TargetPath:  v.smr.VolumePath,
 			Mode:        formatVMGuestFileMode(depVol.Mode),
 		})
 		return nil
 	}
 
-	define.SetVolumeCMap(cmap, path.Base(v.smr.VolumePath), v.smr.VolumePath, false, depVol.Mode)
+	define.SetVolumeCMap(cmap, providerFileName, v.smr.VolumePath, false, depVol.Mode)
 	return nil
 }
 

--- a/worker/appm/volume/share_file_vm_test.go
+++ b/worker/appm/volume/share_file_vm_test.go
@@ -402,6 +402,115 @@ func TestConfigFileVolumeCreateDependVolumeForVMUsesProviderIdentity(t *testing.
 	}
 }
 
+// capability_id: rainbond.config-file.dependent-source-key
+func TestConfigFileVolumeCreateDependVolumeUsesProviderFileKey(t *testing.T) {
+	const (
+		consumerID = "consumer-service"
+		providerID = "config-provider"
+		volumeName = "nginx-config"
+		sourcePath = "/source/nginx.conf"
+		targetPath = "/etc/nginx/conf.d/test1.conf"
+	)
+	as := newDeploymentAppServiceForVolumeTest()
+	as.ServiceID = consumerID
+	depVolume := &dbmodel.TenantServiceVolume{
+		ServiceID:  providerID,
+		VolumeName: volumeName,
+		VolumePath: sourcePath,
+		VolumeType: dbmodel.ConfigFileVolumeType.String(),
+	}
+	mountRelation := &dbmodel.TenantServiceMountRelation{
+		ServiceID:       consumerID,
+		DependServiceID: providerID,
+		VolumeName:      volumeName,
+		VolumePath:      targetPath,
+		VolumeType:      dbmodel.ConfigFileVolumeType.String(),
+	}
+	manager := volumeManagerStub{
+		volumeDao:  tenantServiceVolumeDaoStub{volume: depVolume},
+		serviceDao: tenantServiceDaoStub{service: &dbmodel.TenantServices{ServiceID: providerID, ServiceAlias: "provider"}},
+		configFileDao: tenantServiceConfigFileDaoStub{file: &dbmodel.TenantServiceConfigFile{
+			ServiceID:   providerID,
+			VolumeName:  volumeName,
+			FileContent: "server {}\n",
+		}},
+	}
+
+	configVolume := NewVolumeManager(as, depVolume, mountRelation, nil, nil, nil, manager, true).(*ConfigFileVolume)
+	define := &Define{as: as}
+	if err := configVolume.CreateDependVolume(define); err != nil {
+		t.Fatalf("create dependent deployment config-file volume: %v", err)
+	}
+	if len(as.GetConfigMaps()) != 1 || len(define.GetVolumes()) != 1 || len(define.GetVolumeMounts()) != 1 {
+		t.Fatalf("expected one configmap, volume and mount, got configmaps=%#v volumes=%#v mounts=%#v",
+			as.GetConfigMaps(), define.GetVolumes(), define.GetVolumeMounts())
+	}
+	configMap := as.GetConfigMaps()[0]
+	if configMap.Data["nginx.conf"] != "server {}\n" {
+		t.Fatalf("expected provider source key nginx.conf, got %#v", configMap.Data)
+	}
+	items := define.GetVolumes()[0].ConfigMap.Items
+	if len(items) != 1 || items[0].Key != "nginx.conf" || items[0].Path != "test1.conf" {
+		t.Fatalf("expected provider key nginx.conf mapped to consumer path test1.conf, got %#v", items)
+	}
+	mount := define.GetVolumeMounts()[0]
+	if mount.MountPath != targetPath || mount.SubPath != "test1.conf" {
+		t.Fatalf("expected consumer target path and subPath to be preserved, got %#v", mount)
+	}
+}
+
+// capability_id: rainbond.config-file.dependent-source-key
+func TestConfigFileVolumeCreateDependVolumeForVMUsesProviderFileKey(t *testing.T) {
+	const (
+		consumerID = "vm-consumer"
+		providerID = "config-provider"
+		volumeName = "runtime-config"
+		sourcePath = "/source/rainbond.env"
+		targetPath = "/etc/rainbond/runtime.env"
+	)
+	as := newVMAppServiceForVolumeTest()
+	as.ServiceID = consumerID
+	depVolume := &dbmodel.TenantServiceVolume{
+		ServiceID:  providerID,
+		VolumeName: volumeName,
+		VolumePath: sourcePath,
+		VolumeType: dbmodel.ConfigFileVolumeType.String(),
+	}
+	mountRelation := &dbmodel.TenantServiceMountRelation{
+		ServiceID:       consumerID,
+		DependServiceID: providerID,
+		VolumeName:      volumeName,
+		VolumePath:      targetPath,
+		VolumeType:      dbmodel.ConfigFileVolumeType.String(),
+	}
+	manager := volumeManagerStub{
+		volumeDao:  tenantServiceVolumeDaoStub{volume: depVolume},
+		serviceDao: tenantServiceDaoStub{service: &dbmodel.TenantServices{ServiceID: providerID, ServiceAlias: "provider-vm"}},
+		configFileDao: tenantServiceConfigFileDaoStub{file: &dbmodel.TenantServiceConfigFile{
+			ServiceID:   providerID,
+			VolumeName:  volumeName,
+			FileContent: "DEMO=true\n",
+		}},
+	}
+
+	configVolume := NewVolumeManager(as, depVolume, mountRelation, nil, nil, nil, manager, true).(*ConfigFileVolume)
+	define := &Define{as: as}
+	if err := configVolume.CreateDependVolume(define); err != nil {
+		t.Fatalf("create dependent vm config-file volume: %v", err)
+	}
+	if len(as.GetConfigMaps()) != 1 || len(define.GetVMGuestFiles()) != 1 {
+		t.Fatalf("expected one configmap and VM guest file, got configmaps=%#v guestFiles=%#v",
+			as.GetConfigMaps(), define.GetVMGuestFiles())
+	}
+	if as.GetConfigMaps()[0].Data["rainbond.env"] != "DEMO=true\n" {
+		t.Fatalf("expected provider source key rainbond.env, got %#v", as.GetConfigMaps()[0].Data)
+	}
+	guestFile := define.GetVMGuestFiles()[0]
+	if guestFile.SourceFile != "rainbond.env" || guestFile.TargetPath != targetPath {
+		t.Fatalf("expected provider source rainbond.env injected at consumer target %q, got %#v", targetPath, guestFile)
+	}
+}
+
 // capability_id: rainbond.vm-volume-selected-storage-class
 func TestNewVolumeManagerUsesSelectedStorageClassForVMDisks(t *testing.T) {
 	as := newVMAppServiceForVolumeTest()


### PR DESCRIPTION
## Summary

- map provider ConfigMap source keys to consumer target file paths for container and VM mounts
- safely migrate legacy dependent ConfigMaps with create/update conflict retries
- delete mount relations by consumer, provider, and volume name to avoid same-name collisions
- add managed regression coverage for current and legacy mount paths

## Verification

- go test ./... -count=1
- go vet ./...
- go build ./...
- make check

## Related

- Console consistency: https://github.com/goodrain/rainbond-console/pull/2111
- UI mount visibility: https://github.com/goodrain/rainbond-ui/pull/1910