### PR TITLE
fix: reconcile TCP NodePort lifecycle

### DIFF
--- a/api/controller/apigateway/api_gateway_route.go
+++ b/api/controller/apigateway/api_gateway_route.go
@@ -556,22 +556,6 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 		spec.Selector = kbutil.GenerateKubeBlocksSelector(rbdService.K8sComponentName)
 		logrus.Infof("Using KubeBlocks selector for service %s (k8s_component_name: %s)", serviceName, rbdService.K8sComponentName)
 	}
-	if !autoAllocatePort {
-		rules, err := db.GetManager().TCPRuleDao().GetUsedPortsByIP("0.0.0.0")
-		if err != nil {
-			logrus.Errorf("get used TCP ports error: %v", err)
-			httputil.ReturnBcodeError(r, w, bcode.ErrRouteCreate)
-			return
-		}
-		for _, rule := range rules {
-			sameOwner := resolvedServiceID != "" && rule.ServiceID == resolvedServiceID
-			if rule.Port == int(apisixRouteStream.Match.IngressPort) && !sameOwner {
-				httputil.ReturnBcodeError(r, w, bcode.ErrPortExists)
-				return
-			}
-		}
-	}
-
 	// Try to get the existing service first
 	service, err := k.Services(tenant.Namespace).Get(r.Context(), name, v1.GetOptions{})
 	if err != nil {
@@ -603,7 +587,8 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 			// 设置服务的 NodePort
 			nodePort := service.Spec.Ports[0].NodePort
 			// 创建服务
-			_, err = k.Services(tenant.Namespace).Create(r.Context(), service, v1.CreateOptions{})
+			createdService, createErr := k.Services(tenant.Namespace).Create(r.Context(), service, v1.CreateOptions{})
+			err = createErr
 			if err != nil {
 				if strings.Contains(err.Error(), "provided port is already allocated") {
 					if !autoAllocatePort {
@@ -626,7 +611,8 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 			}
-			apisixRouteStream.Match.IngressPort = nodePort
+			service = createdService
+			apisixRouteStream.Match.IngressPort = service.Spec.Ports[0].NodePort
 			// 如果创建成功，退出循环
 			logrus.Infof("Service created successfully with NodePort %d", nodePort)
 			serviceCreated = true
@@ -639,14 +625,21 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		// Service exists, update it
+		if resolvedServiceID != "" && service.Labels["service_id"] != resolvedServiceID {
+			logrus.Warnf("refusing to update TCP route Service %s owned by service %q for requested service %q",
+				name, service.Labels["service_id"], resolvedServiceID)
+			httputil.ReturnBcodeError(r, w, bcode.ErrPortExists)
+			return
+		}
 		logrus.Infof("Service %s already exists, updating it", name)
 		service.Spec = spec
-		_, err = k.Services(tenant.Namespace).Update(r.Context(), service, v1.UpdateOptions{})
+		service, err = k.Services(tenant.Namespace).Update(r.Context(), service, v1.UpdateOptions{})
 		if err != nil {
 			logrus.Errorf("update route error %s", err.Error())
 			httputil.ReturnBcodeError(r, w, bcode.ErrPortExists)
 			return
 		}
+		apisixRouteStream.Match.IngressPort = service.Spec.Ports[0].NodePort
 	}
 
 	// Add or update the TCP rule in the database
@@ -657,8 +650,8 @@ func (g Struct) CreateTCPRoute(w http.ResponseWriter, r *http.Request) {
 		IP:            "0.0.0.0",
 		Port:          int(apisixRouteStream.Match.IngressPort),
 	}
-	if err := db.GetManager().TCPRuleDao().AddModel(tcpRule); err != nil {
-		logrus.Errorf("add tcp %s", err.Error())
+	if err := db.GetManager().TCPRuleDao().ReplaceByIPAndPort(tcpRule); err != nil {
+		logrus.Errorf("reconcile tcp rule: %s", err.Error())
 		httputil.ReturnBcodeError(r, w, bcode.ErrPortExists)
 		return
 	}
@@ -678,6 +671,8 @@ func (g Struct) UpdateTCPRoute(w http.ResponseWriter, r *http.Request) {
 func (g Struct) DeleteTCPRoute(w http.ResponseWriter, r *http.Request) {
 	tenant := r.Context().Value(ctxutil.ContextKey("tenant")).(*dbmodel.Tenants)
 	name := chi.URLParam(r, "name")
+	requestedName := name
+	requestedServiceID := r.URL.Query().Get("service_id")
 
 	k := k8s.Default().Clientset.CoreV1()
 
@@ -692,8 +687,23 @@ func (g Struct) DeleteTCPRoute(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if service == nil {
+				if err := releaseAbsentTCPRouteRules(requestedName, requestedServiceID); err != nil {
+					logrus.Errorf("release already deleted TCP route %s rules: %v", requestedName, err)
+					httputil.ReturnBcodeError(r, w, bcode.ErrRouteDelete)
+					return
+				}
 				logrus.Infof("Service %s not found, treating as already deleted", name)
 				httputil.ReturnSuccess(r, w, name)
+				return
+			}
+			if requestedServiceID != "" && service.Labels["service_id"] != requestedServiceID {
+				if err := releaseAbsentTCPRouteRules(requestedName, requestedServiceID); err != nil {
+					logrus.Errorf("release replaced TCP route %s rules: %v", requestedName, err)
+					httputil.ReturnBcodeError(r, w, bcode.ErrRouteDelete)
+					return
+				}
+				logrus.Infof("TCP route Service %s now belongs to another service, treating %s as already deleted", service.Name, requestedName)
+				httputil.ReturnSuccess(r, w, requestedName)
 				return
 			}
 			logrus.Infof("Service %s not found, fallback to TCP route Service %s by NodePort", name, service.Name)
@@ -704,21 +714,95 @@ func (g Struct) DeleteTCPRoute(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if requestedServiceID != "" && service.Labels["service_id"] != requestedServiceID {
+		if err := releaseAbsentTCPRouteRules(requestedName, requestedServiceID); err != nil {
+			logrus.Errorf("release replaced TCP route %s rules: %v", requestedName, err)
+			httputil.ReturnBcodeError(r, w, bcode.ErrRouteDelete)
+			return
+		}
+		logrus.Infof("TCP route Service %s belongs to another service, treating %s as already deleted", service.Name, requestedName)
+		httputil.ReturnSuccess(r, w, requestedName)
+		return
+	}
+
+	resolvedServiceID := requestedServiceID
+	if resolvedServiceID == "" {
+		resolvedServiceID = service.Labels["service_id"]
+	}
+	nodePort := tcpRouteServiceNodePort(service)
+	capturedRuleIDs, err := captureTCPRouteRuleIDs(nodePort, "")
+	if err != nil {
+		logrus.Errorf("capture TCP route %s rules for service %s: %v", name, resolvedServiceID, err)
+		httputil.ReturnBcodeError(r, w, bcode.ErrRouteDelete)
+		return
+	}
 
 	// Log the Service details for debugging
 	logrus.Infof("Deleting TCP route Service: %s, labels: %v, port: %v",
 		name, service.Labels, service.Spec.Ports[0].Port)
 
 	// Delete the Service
-	err = k.Services(tenant.Namespace).Delete(r.Context(), name, v1.DeleteOptions{})
-	if err != nil {
+	serviceUID := service.UID
+	err = k.Services(tenant.Namespace).Delete(r.Context(), name, v1.DeleteOptions{
+		Preconditions: &v1.Preconditions{UID: &serviceUID},
+	})
+	if err != nil && !errors.IsNotFound(err) {
 		logrus.Errorf("delete route error %s", err.Error())
+		httputil.ReturnBcodeError(r, w, bcode.ErrRouteDelete)
+		return
+	}
+	if err := db.GetManager().TCPRuleDao().DeleteByRecordIDs(capturedRuleIDs); err != nil {
+		logrus.Errorf("release captured TCP route %s rules: %v", name, err)
 		httputil.ReturnBcodeError(r, w, bcode.ErrRouteDelete)
 		return
 	}
 
 	logrus.Infof("Successfully deleted TCP route Service: %s", name)
 	httputil.ReturnSuccess(r, w, name)
+}
+
+func releaseAbsentTCPRouteRules(routeName, serviceID string) error {
+	if serviceID == "" {
+		// Old clients do not identify the former owner. Once a NodePort is reused,
+		// deleting by port alone could remove the new owner's rule.
+		return nil
+	}
+	nodePort, ok := nodePortFromTCPRouteName(routeName)
+	if !ok {
+		return nil
+	}
+	ruleIDs, err := captureTCPRouteRuleIDs(nodePort, serviceID)
+	if err != nil {
+		return err
+	}
+	return db.GetManager().TCPRuleDao().DeleteByRecordIDs(ruleIDs)
+}
+
+func captureTCPRouteRuleIDs(nodePort int32, serviceID string) ([]uint, error) {
+	if nodePort == 0 {
+		return nil, nil
+	}
+	rules, err := db.GetManager().TCPRuleDao().ListByIPAndPort("0.0.0.0", int(nodePort))
+	if err != nil {
+		return nil, err
+	}
+	ruleIDs := make([]uint, 0, len(rules))
+	for _, rule := range rules {
+		if serviceID != "" && rule.ServiceID != serviceID {
+			continue
+		}
+		ruleIDs = append(ruleIDs, rule.ID)
+	}
+	return ruleIDs, nil
+}
+
+func tcpRouteServiceNodePort(service *corev1.Service) int32 {
+	for _, port := range service.Spec.Ports {
+		if port.NodePort != 0 {
+			return port.NodePort
+		}
+	}
+	return 0
 }
 
 func findTCPRouteServiceByNodePort(ctx context.Context, services typedcorev1.ServiceInterface, routeName string) (*corev1.Service, error) {
@@ -748,8 +832,8 @@ func nodePortFromTCPRouteName(routeName string) (int32, bool) {
 	if idx == -1 || idx == len(routeName)-1 {
 		return 0, false
 	}
-	port, err := strconv.Atoi(routeName[idx+1:])
-	if err != nil {
+	port, err := strconv.ParseInt(routeName[idx+1:], 10, 64)
+	if err != nil || port < 1 || port > 65535 {
 		return 0, false
 	}
 	return int32(port), true

--- a/api/controller/apigateway/api_gateway_route_test.go
+++ b/api/controller/apigateway/api_gateway_route_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -61,8 +62,12 @@ func (d *tcpRouteTenantServiceDao) GetServiceByID(serviceID string) (*dbmodel.Te
 
 type tcpRouteRuleDao struct {
 	dbdao.TCPRuleDao
-	added     *dbmodel.TCPRule
-	usedRules []*dbmodel.TCPRule
+	added             *dbmodel.TCPRule
+	replaced          *dbmodel.TCPRule
+	rules             []*dbmodel.TCPRule
+	deletedIDs        []uint
+	beforeDeleteByIDs func()
+	afterListByIPPort func()
 }
 
 func (d *tcpRouteRuleDao) AddModel(m dbmodel.Interface) error {
@@ -71,7 +76,57 @@ func (d *tcpRouteRuleDao) AddModel(m dbmodel.Interface) error {
 }
 
 func (d *tcpRouteRuleDao) GetUsedPortsByIP(string) ([]*dbmodel.TCPRule, error) {
-	return d.usedRules, nil
+	return d.rules, nil
+}
+
+func (d *tcpRouteRuleDao) ReplaceByIPAndPort(rule *dbmodel.TCPRule) error {
+	canonical := *rule
+	d.replaced = &canonical
+	remaining := make([]*dbmodel.TCPRule, 0, len(d.rules)+1)
+	for _, existing := range d.rules {
+		if existing.IP == rule.IP && existing.Port == rule.Port {
+			continue
+		}
+		if rule.UUID != "" && existing.UUID == rule.UUID {
+			continue
+		}
+		remaining = append(remaining, existing)
+	}
+	remaining = append(remaining, &canonical)
+	d.rules = remaining
+	return nil
+}
+
+func (d *tcpRouteRuleDao) ListByIPAndPort(ip string, port int) ([]*dbmodel.TCPRule, error) {
+	var rules []*dbmodel.TCPRule
+	for _, rule := range d.rules {
+		if rule.IP == ip && rule.Port == port {
+			rules = append(rules, rule)
+		}
+	}
+	if d.afterListByIPPort != nil {
+		d.afterListByIPPort()
+	}
+	return rules, nil
+}
+
+func (d *tcpRouteRuleDao) DeleteByRecordIDs(ids []uint) error {
+	d.deletedIDs = append(d.deletedIDs, ids...)
+	if d.beforeDeleteByIDs != nil {
+		d.beforeDeleteByIDs()
+	}
+	deleted := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		deleted[id] = struct{}{}
+	}
+	remaining := make([]*dbmodel.TCPRule, 0, len(d.rules))
+	for _, rule := range d.rules {
+		if _, ok := deleted[rule.ID]; !ok {
+			remaining = append(remaining, rule)
+		}
+	}
+	d.rules = remaining
+	return nil
 }
 
 func newTCPRouteTestClientset(t *testing.T, services map[string]*corev1.Service) (*kubernetes.Clientset, func()) {
@@ -118,6 +173,28 @@ func newTCPRouteTestClientset(t *testing.T, services map[string]*corev1.Service)
 			if err := json.NewDecoder(r.Body).Decode(&service); err != nil {
 				t.Fatalf("decode service: %v", err)
 			}
+			for _, existing := range services {
+				for _, existingPort := range existing.Spec.Ports {
+					for _, requestedPort := range service.Spec.Ports {
+						if requestedPort.NodePort == 0 || requestedPort.NodePort != existingPort.NodePort {
+							continue
+						}
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						_ = json.NewEncoder(w).Encode(v1.Status{
+							TypeMeta: v1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+							Status:   v1.StatusFailure,
+							Message: fmt.Sprintf(
+								"Service %q is invalid: spec.ports[0].nodePort: Invalid value: %d: provided port is already allocated",
+								service.Name,
+								requestedPort.NodePort,
+							),
+							Reason: v1.StatusReasonInvalid,
+							Code:   http.StatusUnprocessableEntity,
+						})
+						return
+					}
+				}
+			}
 			service.Namespace = "default"
 			services[service.Name] = &service
 			w.WriteHeader(http.StatusCreated)
@@ -126,9 +203,37 @@ func newTCPRouteTestClientset(t *testing.T, services map[string]*corev1.Service)
 			}
 			return
 		}
+		if r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/namespaces/default/services/") {
+			name := strings.TrimPrefix(r.URL.Path, "/api/v1/namespaces/default/services/")
+			existing, ok := services[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(v1.Status{
+					TypeMeta: v1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+					Status:   v1.StatusFailure,
+					Reason:   v1.StatusReasonNotFound,
+					Code:     http.StatusNotFound,
+				})
+				return
+			}
+			var service corev1.Service
+			if err := json.NewDecoder(r.Body).Decode(&service); err != nil {
+				t.Fatalf("decode updated service: %v", err)
+			}
+			service.Namespace = "default"
+			if service.UID == "" {
+				service.UID = existing.UID
+			}
+			services[name] = &service
+			if err := json.NewEncoder(w).Encode(&service); err != nil {
+				t.Fatalf("encode updated service: %v", err)
+			}
+			return
+		}
 		if r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/namespaces/default/services/") {
 			name := strings.TrimPrefix(r.URL.Path, "/api/v1/namespaces/default/services/")
-			if _, ok := services[name]; !ok {
+			existing, ok := services[name]
+			if !ok {
 				w.WriteHeader(http.StatusNotFound)
 				_ = json.NewEncoder(w).Encode(v1.Status{
 					TypeMeta: v1.TypeMeta{
@@ -138,6 +243,19 @@ func newTCPRouteTestClientset(t *testing.T, services map[string]*corev1.Service)
 					Status: v1.StatusFailure,
 					Reason: v1.StatusReasonNotFound,
 					Code:   http.StatusNotFound,
+				})
+				return
+			}
+			var options v1.DeleteOptions
+			_ = json.NewDecoder(r.Body).Decode(&options)
+			if options.Preconditions != nil && options.Preconditions.UID != nil && *options.Preconditions.UID != existing.UID {
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(v1.Status{
+					TypeMeta: v1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+					Status:   v1.StatusFailure,
+					Message:  fmt.Sprintf("Operation cannot be fulfilled on services %q: UID precondition failed", name),
+					Reason:   v1.StatusReasonConflict,
+					Code:     http.StatusConflict,
 				})
 				return
 			}
@@ -330,16 +448,16 @@ func TestCreateTCPRouteUsesRainbondServiceAliasFromBackendServiceLabels(t *testi
 	if got := created.Labels["service_id"]; got != serviceID {
 		t.Fatalf("expected label service_id %q, got %q", serviceID, got)
 	}
-	if ruleDao.added == nil {
-		t.Fatal("expected TCP rule to be persisted")
+	if ruleDao.replaced == nil {
+		t.Fatal("expected TCP rule to be reconciled")
 	}
-	if got := ruleDao.added.ServiceID; got != serviceID {
+	if got := ruleDao.replaced.ServiceID; got != serviceID {
 		t.Fatalf("expected TCP rule service_id %q, got %q", serviceID, got)
 	}
 }
 
-// capability_id: rainbond.gateway.reject-duplicate-tcp-nodeport
-func TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService(t *testing.T) {
+// capability_id: rainbond.gateway.reconcile-stale-tcp-nodeport-rules
+func TestCreateTCPRouteReconcilesStaleDatabaseRules(t *testing.T) {
 	const (
 		namespace     = "default"
 		tenantID      = "tenant-id"
@@ -354,14 +472,83 @@ func TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService(t *testing.T) {
 	defer closeServer()
 	k8s.New().Clientset = clientset
 
-	ruleDao := &tcpRouteRuleDao{usedRules: []*dbmodel.TCPRule{
+	ruleDao := &tcpRouteRuleDao{rules: []*dbmodel.TCPRule{
 		{
-			UUID:      "rule-a",
+			Model:     dbmodel.Model{ID: 1},
+			UUID:      "service-a",
 			ServiceID: "service-a",
 			IP:        "0.0.0.0",
 			Port:      int(requestedPort),
 		},
+		{
+			Model: dbmodel.Model{ID: 2},
+			IP:    "0.0.0.0",
+			Port:  int(requestedPort),
+		},
 	}}
+	db.SetTestManager(tcpRouteTestManager{
+		tenantServiceDao: &tcpRouteTenantServiceDao{servicesByID: map[string]*dbmodel.TenantServices{
+			serviceID: {
+				ServiceID:    serviceID,
+				ServiceAlias: serviceAlias,
+				TenantID:     tenantID,
+			},
+		}},
+		tcpRuleDao: ruleDao,
+	})
+	defer db.SetTestManager(nil)
+
+	rr := createTCPRouteForTest(t, namespace, tenantID, serviceID, serviceName, requestedPort)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if ruleDao.replaced == nil {
+		t.Fatal("expected stale TCP rules to be reconciled")
+	}
+	if ruleDao.replaced.ServiceID != serviceID || ruleDao.replaced.Port != int(requestedPort) {
+		t.Fatalf("unexpected canonical TCP rule: %#v", ruleDao.replaced)
+	}
+	if len(ruleDao.rules) != 1 || ruleDao.rules[0].ServiceID != serviceID {
+		t.Fatalf("expected one canonical TCP rule, got %#v", ruleDao.rules)
+	}
+	if _, ok := services[serviceName+"-30000"]; !ok {
+		t.Fatal("expected Kubernetes NodePort service to be created")
+	}
+}
+
+// capability_id: rainbond.gateway.reject-duplicate-tcp-nodeport
+func TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService(t *testing.T) {
+	const (
+		namespace     = "default"
+		tenantID      = "tenant-id"
+		serviceID     = "service-b"
+		serviceAlias  = "service-b-alias"
+		serviceName   = "service-b-name"
+		requestedPort = int32(30000)
+	)
+
+	services := map[string]*corev1.Service{
+		"service-a-30000": {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "service-a-30000",
+				Namespace: namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:     "service-a-30000",
+					Protocol: corev1.ProtocolTCP,
+					Port:     8080,
+					NodePort: requestedPort,
+				}},
+				Type: corev1.ServiceTypeNodePort,
+			},
+		},
+	}
+	clientset, closeServer := newTCPRouteTestClientset(t, services)
+	defer closeServer()
+	k8s.New().Clientset = clientset
+
+	ruleDao := &tcpRouteRuleDao{}
 	db.SetTestManager(tcpRouteTestManager{
 		tenantServiceDao: &tcpRouteTenantServiceDao{servicesByID: map[string]*dbmodel.TenantServices{
 			serviceID: {
@@ -402,12 +589,133 @@ func TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService(t *testing.T) {
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d: %s", rr.Code, rr.Body.String())
 	}
-	if ruleDao.added != nil {
-		t.Fatalf("expected conflicting TCP rule not to be persisted, got %#v", ruleDao.added)
+	var response struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode conflict response: %v", err)
+	}
+	if response.Code != 50005 {
+		t.Fatalf("expected error code 50005, got %d: %s", response.Code, rr.Body.String())
+	}
+	if ruleDao.replaced != nil {
+		t.Fatalf("expected conflicting TCP rule not to be reconciled, got %#v", ruleDao.replaced)
 	}
 	if _, ok := services[serviceName+"-30000"]; ok {
 		t.Fatal("expected conflicting NodePort service not to be created")
 	}
+}
+
+// capability_id: rainbond.gateway.protect-tcp-route-service-ownership
+func TestCreateTCPRouteRejectsExistingServiceWithoutMatchingOwner(t *testing.T) {
+	const (
+		namespace     = "default"
+		tenantID      = "tenant-id"
+		serviceID     = "service-a"
+		serviceAlias  = "service-a-alias"
+		serviceName   = "service-a-name"
+		requestedPort = int32(30000)
+		routeName     = "service-a-name-30000"
+	)
+
+	tests := []struct {
+		name              string
+		existingServiceID string
+	}{
+		{name: "missing owner label"},
+		{name: "different owner label", existingServiceID: "service-b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := map[string]string{"tcp": "true", "outer": "true"}
+			if tt.existingServiceID != "" {
+				labels["service_id"] = tt.existingServiceID
+			}
+			services := map[string]*corev1.Service{
+				routeName: {
+					ObjectMeta: v1.ObjectMeta{
+						Name:      routeName,
+						Namespace: namespace,
+						Labels:    labels,
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{
+							Name:     routeName,
+							Protocol: corev1.ProtocolTCP,
+							Port:     8080,
+							NodePort: requestedPort,
+						}},
+						Type: corev1.ServiceTypeNodePort,
+					},
+				},
+			}
+			clientset, closeServer := newTCPRouteTestClientset(t, services)
+			defer closeServer()
+			k8s.New().Clientset = clientset
+
+			ruleDao := &tcpRouteRuleDao{}
+			db.SetTestManager(tcpRouteTestManager{
+				tenantServiceDao: &tcpRouteTenantServiceDao{servicesByID: map[string]*dbmodel.TenantServices{
+					serviceID: {
+						ServiceID:    serviceID,
+						ServiceAlias: serviceAlias,
+						TenantID:     tenantID,
+					},
+				}},
+				tcpRuleDao: ruleDao,
+			})
+			defer db.SetTestManager(nil)
+
+			rr := createTCPRouteForTest(t, namespace, tenantID, serviceID, serviceName, requestedPort)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected status 400, got %d: %s", rr.Code, rr.Body.String())
+			}
+			var response struct {
+				Code int `json:"code"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode ownership response: %v", err)
+			}
+			if response.Code != 50005 {
+				t.Fatalf("expected error code 50005, got %d: %s", response.Code, rr.Body.String())
+			}
+			if ruleDao.replaced != nil {
+				t.Fatalf("expected database rule not to be reconciled, got %#v", ruleDao.replaced)
+			}
+			if got := services[routeName].Spec.Ports[0].Port; got != 8080 {
+				t.Fatalf("expected existing Service not to be updated, got port %d", got)
+			}
+		})
+	}
+}
+
+func createTCPRouteForTest(t *testing.T, namespace, tenantID, serviceID, serviceName string, nodePort int32) *httptest.ResponseRecorder {
+	t.Helper()
+	streamRoute := v2.ApisixRouteStream{
+		Name:     "tcp",
+		Protocol: "tcp",
+		Match: v2.ApisixRouteStreamMatch{
+			IngressPort: nodePort,
+		},
+		Backend: v2.ApisixRouteStreamBackend{
+			ServiceName: serviceName,
+			ServicePort: intstr.FromInt(9090),
+		},
+	}
+	body, err := json.Marshal(streamRoute)
+	if err != nil {
+		t.Fatalf("marshal route: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/?service_id="+serviceID, bytes.NewReader(body))
+	ctx := context.WithValue(req.Context(), ctxutil.ContextKey("tenant"), &dbmodel.Tenants{
+		UUID:      tenantID,
+		Namespace: namespace,
+	})
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	Struct{}.CreateTCPRoute(rr, req)
+	return rr
 }
 
 // capability_id: rainbond.api-gateway.vm-nodeport-service-uses-local-external-traffic-policy
@@ -627,6 +935,9 @@ func TestDeleteTCPRouteFallsBackToNodePortWhenNameDiffers(t *testing.T) {
 	clientset, closeServer := newTCPRouteTestClientset(t, services)
 	defer closeServer()
 	k8s.New().Clientset = clientset
+	ruleDao := &tcpRouteRuleDao{}
+	db.SetTestManager(tcpRouteTestManager{tcpRuleDao: ruleDao})
+	defer db.SetTestManager(nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/"+requestedName, nil)
 	routeCtx := chi.NewRouteContext()
@@ -646,5 +957,308 @@ func TestDeleteTCPRouteFallsBackToNodePortWhenNameDiffers(t *testing.T) {
 	_, err := k8s.Default().Clientset.CoreV1().Services(namespace).Get(context.Background(), actualServiceName, v1.GetOptions{})
 	if !errors.IsNotFound(err) {
 		t.Fatalf("expected actual TCP route service to be deleted, got err %v", err)
+	}
+}
+
+// capability_id: rainbond.gateway.release-captured-tcp-nodeport-rules
+func TestDeleteTCPRouteReleasesOnlyCapturedRuleIDs(t *testing.T) {
+	const (
+		namespace   = "default"
+		serviceID   = "service-a"
+		serviceName = "service-a-30003"
+		nodePort    = int32(30003)
+	)
+
+	services := map[string]*corev1.Service{
+		serviceName: {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"service_id": serviceID,
+					"outer":      "true",
+					"tcp":        "true",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:     serviceName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     8080,
+					NodePort: nodePort,
+				}},
+				Type: corev1.ServiceTypeNodePort,
+			},
+		},
+	}
+	clientset, closeServer := newTCPRouteTestClientset(t, services)
+	defer closeServer()
+	k8s.New().Clientset = clientset
+
+	ruleDao := &tcpRouteRuleDao{rules: []*dbmodel.TCPRule{
+		{Model: dbmodel.Model{ID: 10}, UUID: serviceID, ServiceID: serviceID, IP: "0.0.0.0", Port: int(nodePort)},
+		{Model: dbmodel.Model{ID: 11}, IP: "0.0.0.0", Port: int(nodePort)},
+		{Model: dbmodel.Model{ID: 12}, UUID: serviceID, ServiceID: serviceID, IP: "0.0.0.0", Port: 30004},
+	}}
+	ruleDao.beforeDeleteByIDs = func() {
+		ruleDao.rules = append(ruleDao.rules, &dbmodel.TCPRule{
+			Model:     dbmodel.Model{ID: 13},
+			UUID:      "service-b",
+			ServiceID: "service-b",
+			IP:        "0.0.0.0",
+			Port:      int(nodePort),
+		})
+	}
+	db.SetTestManager(tcpRouteTestManager{tcpRuleDao: ruleDao})
+	defer db.SetTestManager(nil)
+
+	rr := deleteTCPRouteForTest(t, namespace, serviceName, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(ruleDao.deletedIDs) != 2 || ruleDao.deletedIDs[0] != 10 || ruleDao.deletedIDs[1] != 11 {
+		t.Fatalf("expected captured IDs [10 11] to be deleted, got %v", ruleDao.deletedIDs)
+	}
+	if len(ruleDao.rules) != 2 || ruleDao.rules[0].ID != 12 || ruleDao.rules[1].ID != 13 {
+		t.Fatalf("expected non-captured and future rules to remain, got %#v", ruleDao.rules)
+	}
+}
+
+// capability_id: rainbond.gateway.prevent-tcp-route-delete-recreation-race
+func TestDeleteTCPRouteDoesNotDeleteRecreatedServiceWithStaleUID(t *testing.T) {
+	const (
+		namespace   = "default"
+		serviceID   = "service-a"
+		serviceName = "service-a-30003"
+		nodePort    = int32(30003)
+	)
+
+	services := map[string]*corev1.Service{
+		serviceName: {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+				UID:       "old-uid",
+				Labels: map[string]string{
+					"service_id": serviceID,
+					"outer":      "true",
+					"tcp":        "true",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:     serviceName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     8080,
+					NodePort: nodePort,
+				}},
+				Type: corev1.ServiceTypeNodePort,
+			},
+		},
+	}
+	clientset, closeServer := newTCPRouteTestClientset(t, services)
+	defer closeServer()
+	k8s.New().Clientset = clientset
+
+	ruleDao := &tcpRouteRuleDao{rules: []*dbmodel.TCPRule{
+		{Model: dbmodel.Model{ID: 40}, UUID: serviceID, ServiceID: serviceID, IP: "0.0.0.0", Port: int(nodePort)},
+	}}
+	ruleDao.afterListByIPPort = func() {
+		ruleDao.afterListByIPPort = nil
+		services[serviceName] = &corev1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+				UID:       "new-uid",
+				Labels: map[string]string{
+					"service_id": "service-b",
+					"outer":      "true",
+					"tcp":        "true",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:     serviceName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     9090,
+					NodePort: nodePort,
+				}},
+				Type: corev1.ServiceTypeNodePort,
+			},
+		}
+	}
+	db.SetTestManager(tcpRouteTestManager{tcpRuleDao: ruleDao})
+	defer db.SetTestManager(nil)
+
+	rr := deleteTCPRouteForTest(t, namespace, serviceName, serviceID)
+	if rr.Code == http.StatusOK {
+		t.Fatalf("expected stale UID delete to fail, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := services[serviceName]; got == nil || got.UID != "new-uid" {
+		t.Fatalf("expected recreated Service to remain, got %#v", got)
+	}
+	if len(ruleDao.deletedIDs) != 0 || len(ruleDao.rules) != 1 || ruleDao.rules[0].ID != 40 {
+		t.Fatalf("expected captured rules to remain after failed UID precondition, deleted=%v rules=%#v", ruleDao.deletedIDs, ruleDao.rules)
+	}
+}
+
+// capability_id: rainbond.gateway.protect-unlabeled-tcp-route-service
+func TestDeleteTCPRouteWithServiceIDDoesNotDeleteUnlabeledService(t *testing.T) {
+	const (
+		namespace   = "default"
+		serviceID   = "service-a"
+		serviceName = "service-a-30003"
+		nodePort    = int32(30003)
+	)
+
+	services := map[string]*corev1.Service{
+		serviceName: {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+				UID:       "unknown-owner-uid",
+				Labels: map[string]string{
+					"outer": "true",
+					"tcp":   "true",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:     serviceName,
+					Protocol: corev1.ProtocolTCP,
+					Port:     8080,
+					NodePort: nodePort,
+				}},
+				Type: corev1.ServiceTypeNodePort,
+			},
+		},
+	}
+	clientset, closeServer := newTCPRouteTestClientset(t, services)
+	defer closeServer()
+	k8s.New().Clientset = clientset
+
+	ruleDao := &tcpRouteRuleDao{rules: []*dbmodel.TCPRule{
+		{Model: dbmodel.Model{ID: 50}, UUID: serviceID, ServiceID: serviceID, IP: "0.0.0.0", Port: int(nodePort)},
+		{Model: dbmodel.Model{ID: 51}, IP: "0.0.0.0", Port: int(nodePort)},
+		{Model: dbmodel.Model{ID: 52}, UUID: "service-b", ServiceID: "service-b", IP: "0.0.0.0", Port: int(nodePort)},
+	}}
+	db.SetTestManager(tcpRouteTestManager{tcpRuleDao: ruleDao})
+	defer db.SetTestManager(nil)
+
+	rr := deleteTCPRouteForTest(t, namespace, serviceName, serviceID)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected unknown owner to be treated as already deleted, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := services[serviceName]; got == nil || got.UID != "unknown-owner-uid" {
+		t.Fatalf("expected unlabeled Service to remain, got %#v", got)
+	}
+	if len(ruleDao.deletedIDs) != 1 || ruleDao.deletedIDs[0] != 50 {
+		t.Fatalf("expected only requested owner's old rule to be deleted, got %v", ruleDao.deletedIDs)
+	}
+	if len(ruleDao.rules) != 2 || ruleDao.rules[0].ID != 51 || ruleDao.rules[1].ID != 52 {
+		t.Fatalf("expected unknown-owner rules to remain, got %#v", ruleDao.rules)
+	}
+}
+
+// capability_id: rainbond.gateway.release-absent-tcp-nodeport-owner
+func TestDeleteTCPRouteAlreadyAbsentReleasesOnlyRequestedOwner(t *testing.T) {
+	const (
+		namespace   = "default"
+		serviceID   = "service-a"
+		serviceName = "service-a-30003"
+		nodePort    = int32(30003)
+	)
+
+	services := map[string]*corev1.Service{}
+	clientset, closeServer := newTCPRouteTestClientset(t, services)
+	defer closeServer()
+	k8s.New().Clientset = clientset
+
+	ruleDao := &tcpRouteRuleDao{rules: []*dbmodel.TCPRule{
+		{Model: dbmodel.Model{ID: 20}, UUID: serviceID, ServiceID: serviceID, IP: "0.0.0.0", Port: int(nodePort)},
+		{Model: dbmodel.Model{ID: 21}, IP: "0.0.0.0", Port: int(nodePort)},
+		{Model: dbmodel.Model{ID: 22}, UUID: "service-b", ServiceID: "service-b", IP: "0.0.0.0", Port: int(nodePort)},
+	}}
+	db.SetTestManager(tcpRouteTestManager{tcpRuleDao: ruleDao})
+	defer db.SetTestManager(nil)
+
+	rr := deleteTCPRouteForTest(t, namespace, serviceName, serviceID)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(ruleDao.deletedIDs) != 1 || ruleDao.deletedIDs[0] != 20 {
+		t.Fatalf("expected only requested owner's rule ID to be deleted, got %v", ruleDao.deletedIDs)
+	}
+	if len(ruleDao.rules) != 2 || ruleDao.rules[0].ID != 21 || ruleDao.rules[1].ID != 22 {
+		t.Fatalf("expected anonymous and future-owner rules to remain, got %#v", ruleDao.rules)
+	}
+}
+
+func TestDeleteTCPRouteAlreadyAbsentWithoutServiceIDKeepsRules(t *testing.T) {
+	const (
+		namespace   = "default"
+		serviceName = "service-a-30003"
+	)
+
+	services := map[string]*corev1.Service{}
+	clientset, closeServer := newTCPRouteTestClientset(t, services)
+	defer closeServer()
+	k8s.New().Clientset = clientset
+
+	ruleDao := &tcpRouteRuleDao{rules: []*dbmodel.TCPRule{
+		{Model: dbmodel.Model{ID: 30}, UUID: "service-b", ServiceID: "service-b", IP: "0.0.0.0", Port: 30003},
+	}}
+	db.SetTestManager(tcpRouteTestManager{tcpRuleDao: ruleDao})
+	defer db.SetTestManager(nil)
+
+	rr := deleteTCPRouteForTest(t, namespace, serviceName, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(ruleDao.deletedIDs) != 0 || len(ruleDao.rules) != 1 {
+		t.Fatalf("expected old client request not to release an unknown owner, got deleted=%v rules=%#v", ruleDao.deletedIDs, ruleDao.rules)
+	}
+}
+
+func deleteTCPRouteForTest(t *testing.T, namespace, serviceName, serviceID string) *httptest.ResponseRecorder {
+	t.Helper()
+	path := "/" + serviceName
+	if serviceID != "" {
+		path += "?service_id=" + serviceID
+	}
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("name", serviceName)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, ctxutil.ContextKey("tenant"), &dbmodel.Tenants{
+		Namespace: namespace,
+	})
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+	Struct{}.DeleteTCPRoute(rr, req)
+	return rr
+}
+
+// capability_id: rainbond.gateway.validate-tcp-nodeport-route-name
+func TestNodePortFromTCPRouteNameValidatesRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		routeName string
+		wantPort  int32
+		wantOK    bool
+	}{
+		{name: "valid", routeName: "service-a-30003", wantPort: 30003, wantOK: true},
+		{name: "zero", routeName: "service-a-0"},
+		{name: "above maximum", routeName: "service-a-65536"},
+		{name: "int32 wraparound", routeName: "service-a-4294997299"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPort, gotOK := nodePortFromTCPRouteName(tt.routeName)
+			if gotPort != tt.wantPort || gotOK != tt.wantOK {
+				t.Fatalf("nodePortFromTCPRouteName(%q) = (%d, %v), want (%d, %v)", tt.routeName, gotPort, gotOK, tt.wantPort, tt.wantOK)
+			}
+		})
 	}
 }

--- a/db/dao/dao.go
+++ b/db/dao/dao.go
@@ -559,6 +559,9 @@ type TCPRuleDao interface {
 	DeleteTCPRuleByServiceID(serviceID string) error
 	ListByServiceID(serviceID string) ([]*model.TCPRule, error)
 	GetUsedPortsByIP(ip string) ([]*model.TCPRule, error)
+	ReplaceByIPAndPort(tcpRule *model.TCPRule) error
+	ListByIPAndPort(ip string, port int) ([]*model.TCPRule, error)
+	DeleteByRecordIDs(ids []uint) error
 	DeleteByComponentPort(componentID string, port int) error
 	DeleteByComponentIDs(componentIDs []string) error
 	CreateOrUpdateTCPRuleInBatch(tcpRules []*model.TCPRule) error

--- a/db/dao/dao_mock.go
+++ b/db/dao/dao_mock.go
@@ -4736,6 +4736,43 @@ func (mr *MockTCPRuleDaoMockRecorder) GetUsedPortsByIP(ip interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsedPortsByIP", reflect.TypeOf((*MockTCPRuleDao)(nil).GetUsedPortsByIP), ip)
 }
 
+// ReplaceByIPAndPort mocks base method
+func (m *MockTCPRuleDao) ReplaceByIPAndPort(tcpRule *model.TCPRule) error {
+	ret := m.ctrl.Call(m, "ReplaceByIPAndPort", tcpRule)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReplaceByIPAndPort indicates an expected call of ReplaceByIPAndPort
+func (mr *MockTCPRuleDaoMockRecorder) ReplaceByIPAndPort(tcpRule interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceByIPAndPort", reflect.TypeOf((*MockTCPRuleDao)(nil).ReplaceByIPAndPort), tcpRule)
+}
+
+// ListByIPAndPort mocks base method
+func (m *MockTCPRuleDao) ListByIPAndPort(ip string, port int) ([]*model.TCPRule, error) {
+	ret := m.ctrl.Call(m, "ListByIPAndPort", ip, port)
+	ret0, _ := ret[0].([]*model.TCPRule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByIPAndPort indicates an expected call of ListByIPAndPort
+func (mr *MockTCPRuleDaoMockRecorder) ListByIPAndPort(ip, port interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByIPAndPort", reflect.TypeOf((*MockTCPRuleDao)(nil).ListByIPAndPort), ip, port)
+}
+
+// DeleteByRecordIDs mocks base method
+func (m *MockTCPRuleDao) DeleteByRecordIDs(ids []uint) error {
+	ret := m.ctrl.Call(m, "DeleteByRecordIDs", ids)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByRecordIDs indicates an expected call of DeleteByRecordIDs
+func (mr *MockTCPRuleDaoMockRecorder) DeleteByRecordIDs(ids interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByRecordIDs", reflect.TypeOf((*MockTCPRuleDao)(nil).DeleteByRecordIDs), ids)
+}
+
 // MockEndpointsDao is a mock of EndpointsDao interface
 type MockEndpointsDao struct {
 	ctrl     *gomock.Controller

--- a/db/mysql/dao/gateway.go
+++ b/db/mysql/dao/gateway.go
@@ -564,6 +564,55 @@ func (t *TCPRuleDaoTmpl) GetUsedPortsByIP(ip string) ([]*model.TCPRule, error) {
 	return rules, nil
 }
 
+// ReplaceByIPAndPort replaces duplicate TCP rules with one canonical rule.
+func (t *TCPRuleDaoTmpl) ReplaceByIPAndPort(tcpRule *model.TCPRule) error {
+	tx := t.DB.Begin()
+	if tx.Error != nil {
+		return errors.Wrap(tx.Error, "begin replacing tcp rule")
+	}
+
+	query := tx.Where("ip = ? and port = ?", tcpRule.IP, tcpRule.Port)
+	if tcpRule.UUID != "" {
+		query = tx.Where("uuid = ? or (ip = ? and port = ?)", tcpRule.UUID, tcpRule.IP, tcpRule.Port)
+	}
+	if err := query.Delete(&model.TCPRule{}).Error; err != nil {
+		tx.Rollback()
+		return errors.Wrap(err, "delete duplicate tcp rules")
+	}
+
+	canonical := *tcpRule
+	canonical.Model = model.Model{}
+	if err := tx.Create(&canonical).Error; err != nil {
+		tx.Rollback()
+		return errors.Wrap(err, "create canonical tcp rule")
+	}
+	if err := tx.Commit().Error; err != nil {
+		tx.Rollback()
+		return errors.Wrap(err, "commit replacing tcp rule")
+	}
+	return nil
+}
+
+// ListByIPAndPort lists all TCP rules matching an external IP and port.
+func (t *TCPRuleDaoTmpl) ListByIPAndPort(ip string, port int) ([]*model.TCPRule, error) {
+	var rules []*model.TCPRule
+	if err := t.DB.Where("ip = ? and port = ?", ip, port).Find(&rules).Error; err != nil {
+		return nil, errors.Wrap(err, "list tcp rules by ip and port")
+	}
+	return rules, nil
+}
+
+// DeleteByRecordIDs deletes only TCP rules with the captured primary IDs.
+func (t *TCPRuleDaoTmpl) DeleteByRecordIDs(ids []uint) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if err := t.DB.Where("ID in (?)", ids).Delete(&model.TCPRule{}).Error; err != nil {
+		return errors.Wrap(err, "delete tcp rules by record IDs")
+	}
+	return nil
+}
+
 // ListByServiceID lists all TCPRules matching serviceID
 func (t *TCPRuleDaoTmpl) ListByServiceID(serviceID string) ([]*model.TCPRule, error) {
 	var rules []*model.TCPRule

--- a/db/mysql/dao/gateway_test.go
+++ b/db/mysql/dao/gateway_test.go
@@ -127,3 +127,130 @@ func TestTCPRuleDaoAddModelKeepsAnonymousRulesOnDifferentPorts(t *testing.T) {
 		t.Fatalf("expected two anonymous TCP rules, got %d", count)
 	}
 }
+
+func TestTCPRuleDaoReplaceByIPAndPortCollapsesDuplicates(t *testing.T) {
+	db := newTCPRuleTestDB(t)
+	defer db.Close()
+
+	dao := &TCPRuleDaoTmpl{DB: db}
+	seedRules := []*model.TCPRule{
+		{
+			UUID:          "rule-a",
+			ServiceID:     "service-a",
+			ContainerPort: 8080,
+			IP:            "0.0.0.0",
+			Port:          30000,
+		},
+		{
+			UUID:          "rule-b",
+			ServiceID:     "service-b",
+			ContainerPort: 9090,
+			IP:            "0.0.0.0",
+			Port:          30001,
+		},
+		{
+			ContainerPort: 9090,
+			IP:            "0.0.0.0",
+			Port:          30001,
+		},
+	}
+	for _, rule := range seedRules {
+		if err := db.Create(rule).Error; err != nil {
+			t.Fatalf("seed TCP rule: %v", err)
+		}
+	}
+
+	canonical := &model.TCPRule{
+		UUID:          "rule-a",
+		ServiceID:     "service-a",
+		ContainerPort: 8080,
+		IP:            "0.0.0.0",
+		Port:          30001,
+	}
+	if err := dao.ReplaceByIPAndPort(canonical); err != nil {
+		t.Fatalf("replace TCP rules: %v", err)
+	}
+
+	rules, err := dao.ListByIPAndPort("0.0.0.0", 30001)
+	if err != nil {
+		t.Fatalf("list replacement TCP rules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected one canonical TCP rule, got %d", len(rules))
+	}
+	if rules[0].UUID != canonical.UUID ||
+		rules[0].ServiceID != canonical.ServiceID ||
+		rules[0].ContainerPort != canonical.ContainerPort {
+		t.Fatalf("unexpected canonical TCP rule: %#v", rules[0])
+	}
+
+	var oldUUIDCount int
+	if err := db.Model(&model.TCPRule{}).
+		Where("uuid = ? and port = ?", canonical.UUID, 30000).
+		Count(&oldUUIDCount).Error; err != nil {
+		t.Fatalf("count old UUID rule: %v", err)
+	}
+	if oldUUIDCount != 0 {
+		t.Fatalf("expected old UUID rule to be removed, got %d", oldUUIDCount)
+	}
+}
+
+func TestTCPRuleDaoDeleteByRecordIDsDeletesOnlyCapturedRules(t *testing.T) {
+	db := newTCPRuleTestDB(t)
+	defer db.Close()
+
+	dao := &TCPRuleDaoTmpl{DB: db}
+	for _, rule := range []*model.TCPRule{
+		{
+			UUID:          "rule-a",
+			ServiceID:     "service-a",
+			ContainerPort: 8080,
+			IP:            "0.0.0.0",
+			Port:          30001,
+		},
+		{
+			ContainerPort: 8080,
+			IP:            "0.0.0.0",
+			Port:          30001,
+		},
+	} {
+		if err := db.Create(rule).Error; err != nil {
+			t.Fatalf("seed captured TCP rule: %v", err)
+		}
+	}
+
+	captured, err := dao.ListByIPAndPort("0.0.0.0", 30001)
+	if err != nil {
+		t.Fatalf("capture TCP rule IDs: %v", err)
+	}
+	capturedIDs := make([]uint, 0, len(captured))
+	for _, rule := range captured {
+		capturedIDs = append(capturedIDs, rule.ID)
+	}
+
+	newOwner := &model.TCPRule{
+		UUID:          "rule-b",
+		ServiceID:     "service-b",
+		ContainerPort: 9090,
+		IP:            "0.0.0.0",
+		Port:          30001,
+	}
+	if err := db.Create(newOwner).Error; err != nil {
+		t.Fatalf("seed new TCP rule owner: %v", err)
+	}
+
+	if err := dao.DeleteByRecordIDs(capturedIDs); err != nil {
+		t.Fatalf("delete captured TCP rules: %v", err)
+	}
+	if err := dao.DeleteByRecordIDs(nil); err != nil {
+		t.Fatalf("delete empty TCP rule ID list: %v", err)
+	}
+
+	rules, err := dao.ListByIPAndPort("0.0.0.0", 30001)
+	if err != nil {
+		t.Fatalf("list remaining TCP rules: %v", err)
+	}
+	if len(rules) != 1 || rules[0].ID != newOwner.ID {
+		t.Fatalf("expected only the new TCP rule owner to remain, got %#v", rules)
+	}
+}

--- a/test-manifest.json
+++ b/test-manifest.json
@@ -2636,6 +2636,60 @@
       "status": "active"
     },
     {
+      "id": "rainbond.gateway.prevent-tcp-route-delete-recreation-race",
+      "title": "Protect recreated TCP route Services with UID delete preconditions",
+      "title_zh": "Protect recreated TCP route Services with UID delete preconditions",
+      "interface_type": "workflow",
+      "interface": "api/controller/apigateway.Struct.DeleteTCPRoute",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestDeleteTCPRouteDoesNotDeleteRecreatedServiceWithStaleUID"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.gateway.protect-tcp-route-service-ownership",
+      "title": "Reject TCP route updates for missing or different Service owners",
+      "title_zh": "Reject TCP route updates for missing or different Service owners",
+      "interface_type": "workflow",
+      "interface": "api/controller/apigateway.Struct.CreateTCPRoute",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestCreateTCPRouteRejectsExistingServiceWithoutMatchingOwner"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.gateway.protect-unlabeled-tcp-route-service",
+      "title": "Do not delete unlabeled TCP route Services for owned requests",
+      "title_zh": "Do not delete unlabeled TCP route Services for owned requests",
+      "interface_type": "workflow",
+      "interface": "api/controller/apigateway.Struct.DeleteTCPRoute",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestDeleteTCPRouteWithServiceIDDoesNotDeleteUnlabeledService"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
       "id": "rainbond.gateway.reassign-conflicting-imported-tcp-port",
       "title": "Reassign imported TCP ports that conflict with existing NodePorts",
       "interface_type": "package_function",
@@ -2647,6 +2701,24 @@
         {
           "path": "api/handler/gateway_action_test.go",
           "selector": "TestReassignConflictingTCPRulePorts"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.gateway.reconcile-stale-tcp-nodeport-rules",
+      "title": "Reconcile stale TCP NodePort database rules after Kubernetes allocation",
+      "title_zh": "Reconcile stale TCP NodePort database rules after Kubernetes allocation",
+      "interface_type": "workflow",
+      "interface": "api/controller/apigateway.Struct.CreateTCPRoute",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestCreateTCPRouteReconcilesStaleDatabaseRules"
         }
       ],
       "test_type": "regression",
@@ -2670,6 +2742,60 @@
         {
           "path": "api/controller/apigateway/api_gateway_route_test.go",
           "selector": "TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.gateway.release-absent-tcp-nodeport-owner",
+      "title": "Release only the requested owner when a TCP route Service is absent",
+      "title_zh": "Release only the requested owner when a TCP route Service is absent",
+      "interface_type": "workflow",
+      "interface": "api/controller/apigateway.Struct.DeleteTCPRoute",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestDeleteTCPRouteAlreadyAbsentReleasesOnlyRequestedOwner"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.gateway.release-captured-tcp-nodeport-rules",
+      "title": "Release only TCP NodePort rules captured before Service deletion",
+      "title_zh": "Release only TCP NodePort rules captured before Service deletion",
+      "interface_type": "workflow",
+      "interface": "api/controller/apigateway.Struct.DeleteTCPRoute",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestDeleteTCPRouteReleasesOnlyCapturedRuleIDs"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.gateway.validate-tcp-nodeport-route-name",
+      "title": "Reject out-of-range TCP NodePorts parsed from route names",
+      "title_zh": "Reject out-of-range TCP NodePorts parsed from route names",
+      "interface_type": "package_function",
+      "interface": "api/controller/apigateway.nodePortFromTCPRouteName",
+      "code_paths": [
+        "api/controller/apigateway/api_gateway_route.go"
+      ],
+      "tests": [
+        {
+          "path": "api/controller/apigateway/api_gateway_route_test.go",
+          "selector": "TestNodePortFromTCPRouteNameValidatesRange"
         }
       ],
       "test_type": "regression",
@@ -8149,6 +8275,24 @@
         {
           "path": "worker/appm/store/store_test.go",
           "selector": "TestGetAppStatus"
+        }
+      ],
+      "test_type": "regression",
+      "status": "active"
+    },
+    {
+      "id": "rainbond.worker.appm.store.skip-managed-tcp-nodeport-reservation",
+      "title": "Skip anonymous reservations for Rainbond-managed TCP routes",
+      "title_zh": "\u8df3\u8fc7 Rainbond \u7ba1\u7406\u7684 TCP \u8def\u7531\u533f\u540d\u7aef\u53e3\u9884\u7559",
+      "interface_type": "workflow",
+      "interface": "worker/appm/store.shouldTrackNodePortService",
+      "code_paths": [
+        "worker/appm/store/store.go"
+      ],
+      "tests": [
+        {
+          "path": "worker/appm/store/store_test.go",
+          "selector": "TestShouldTrackNodePortService"
         }
       ],
       "test_type": "regression",

--- a/test-manifest.md
+++ b/test-manifest.md
@@ -144,8 +144,15 @@
 | rainbond.gateway.allocate-lb-port | 分配可用网关负载均衡端口 | active | regression | api/handler.selectAvailablePort | api/handler/gateway_action_test.go::TestSelectAvailablePort |
 | rainbond.gateway.certificate-resource-consistency | Keep gateway certificate resources consistent | active | regression | api/handler.GatewayAction.AddGatewayCertificate | api/handler/gateway_action_test.go::TestGatewayCertificateResourceConsistency |
 | rainbond.gateway.http-route-delete-component-event | 删除网关 HTTPRoute 时记录组件事件 | active | regression | github.com/goodrain/rainbond/api/handler.(*GatewayAction).DeleteGatewayHTTPRoute | api/handler/gateway_action_test.go::TestCreateGatewayHTTPRouteDeleteEvents |
+| rainbond.gateway.prevent-tcp-route-delete-recreation-race | Protect recreated TCP route Services with UID delete preconditions | active | regression | api/controller/apigateway.Struct.DeleteTCPRoute | api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteDoesNotDeleteRecreatedServiceWithStaleUID |
+| rainbond.gateway.protect-tcp-route-service-ownership | Reject TCP route updates for missing or different Service owners | active | regression | api/controller/apigateway.Struct.CreateTCPRoute | api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteRejectsExistingServiceWithoutMatchingOwner |
+| rainbond.gateway.protect-unlabeled-tcp-route-service | Do not delete unlabeled TCP route Services for owned requests | active | regression | api/controller/apigateway.Struct.DeleteTCPRoute | api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteWithServiceIDDoesNotDeleteUnlabeledService |
 | rainbond.gateway.reassign-conflicting-imported-tcp-port | Reassign imported TCP ports that conflict with existing NodePorts | active | regression | api/handler.reassignConflictingTCPRulePorts | api/handler/gateway_action_test.go::TestReassignConflictingTCPRulePorts |
+| rainbond.gateway.reconcile-stale-tcp-nodeport-rules | Reconcile stale TCP NodePort database rules after Kubernetes allocation | active | regression | api/controller/apigateway.Struct.CreateTCPRoute | api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteReconcilesStaleDatabaseRules |
 | rainbond.gateway.reject-duplicate-tcp-nodeport | Reject duplicate TCP NodePort bindings | active | regression | TCP NodePort binding | db/mysql/dao/gateway_test.go::TestTCPRuleDaoAddModelRejectsPortOwnedByAnotherRule<br>api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService |
+| rainbond.gateway.release-absent-tcp-nodeport-owner | Release only the requested owner when a TCP route Service is absent | active | regression | api/controller/apigateway.Struct.DeleteTCPRoute | api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteAlreadyAbsentReleasesOnlyRequestedOwner |
+| rainbond.gateway.release-captured-tcp-nodeport-rules | Release only TCP NodePort rules captured before Service deletion | active | regression | api/controller/apigateway.Struct.DeleteTCPRoute | api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteReleasesOnlyCapturedRuleIDs |
+| rainbond.gateway.validate-tcp-nodeport-route-name | Reject out-of-range TCP NodePorts parsed from route names | active | regression | api/controller/apigateway.nodePortFromTCPRouteName | api/controller/apigateway/api_gateway_route_test.go::TestNodePortFromTCPRouteNameValidatesRange |
 | rainbond.helm-release.app-version-format | 为 Helm 历史输出格式化应用版本号 | active | regression | pkg/helm.formatAppVersion | pkg/helm/helm_release_test.go::TestGetReleaseHistory |
 | rainbond.helm-release.chart-name-format | 为历史和摘要输出格式化 Helm chart 名称 | active | regression | pkg/helm.formatChartName | pkg/helm/helm_release_test.go::TestGetReleaseHistory |
 | rainbond.helm-release.classify-resources | 按资源类型归类 Helm 发布资源 | active | regression | api/handler.splitHelmReleaseResources | api/handler/helm_release_test.go::TestSplitHelmReleaseResourcesClassifiesKinds |
@@ -434,6 +441,7 @@
 | rainbond.worker.appm.gateway.vm-nodeport-service-uses-local-external-traffic-policy | Use Local externalTrafficPolicy for VM worker NodePort services | active | regression | worker/appm/conversion.outerServiceExternalTrafficPolicy | worker/appm/conversion/gateway_test.go::TestOuterServiceExternalTrafficPolicyForVM<br>worker/appm/conversion/gateway_test.go::TestOuterServiceExternalTrafficPolicyForNonVM |
 | rainbond.worker.appm.patch.statefulset-modified-configuration | 根据新旧工作负载规格计算允许的 StatefulSet Patch 内容 | active | regression | worker/appm/types/v1.getStatefulsetModifiedConfiguration | worker/appm/types/v1/patch_test.go::TestGetStatefulsetModifiedConfiguration |
 | rainbond.worker.appm.store.aggregate-app-status | 将组件运行状态汇总为应用状态 | active | regression | worker/appm/store.getAppStatus | worker/appm/store/store_test.go::TestGetAppStatus |
+| rainbond.worker.appm.store.skip-managed-tcp-nodeport-reservation | 跳过 Rainbond 管理的 TCP 路由匿名端口预留 | active | regression | worker/appm/store.shouldTrackNodePortService | worker/appm/store/store_test.go::TestShouldTrackNodePortService |
 | rainbond.worker.appm.store.sync-managed-namespace-image-pull-secret | 在命名空间事件中同步受管命名空间的镜像拉取密钥 | active | regression | worker/appm/store.appRuntimeStore.nsEventHandler | worker/appm/store/store_test.go::TestNsEventHandlerProvidesAddFunc |
 | rainbond.worker.appm.vm-boot-media-paths | 拆分 ISO 与 QCOW2 的 VM 启动介质组装路径 | active | regression | worker/appm/conversion.TenantServiceVersion | worker/appm/conversion/version_vm_test.go::TestResolveVMBootPathUsesISOInstallerWhenRootDiskIsBlank<br>worker/appm/conversion/version_vm_test.go::TestApplyVMBootVolumeLayoutDropsInstallerVolumeWhenDiskLayoutRemovesIt |
 | rainbond.worker.appm.vm-container-disk-cdrom | VM container disk CD-ROM media | active | regression | worker/appm/conversion.appendVMContainerDiskCDROMs | worker/appm/conversion/vm_runtime_test.go::TestBuildVMDiskLayoutKeepsContainerDiskImage<br>worker/appm/conversion/vm_runtime_test.go::TestAppendVMContainerDiskCDROMsCreatesContainerDiskVolumeAndDisk |
@@ -1874,6 +1882,36 @@
 - 代码路径: `api/handler/gateway_action.go`
 - 测试路径: `api/handler/gateway_action_test.go::TestCreateGatewayHTTPRouteDeleteEvents`
 
+### Protect recreated TCP route Services with UID delete preconditions
+
+- Capability ID: `rainbond.gateway.prevent-tcp-route-delete-recreation-race`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `api/controller/apigateway.Struct.DeleteTCPRoute`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteDoesNotDeleteRecreatedServiceWithStaleUID`
+
+### Reject TCP route updates for missing or different Service owners
+
+- Capability ID: `rainbond.gateway.protect-tcp-route-service-ownership`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `api/controller/apigateway.Struct.CreateTCPRoute`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteRejectsExistingServiceWithoutMatchingOwner`
+
+### Do not delete unlabeled TCP route Services for owned requests
+
+- Capability ID: `rainbond.gateway.protect-unlabeled-tcp-route-service`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `api/controller/apigateway.Struct.DeleteTCPRoute`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteWithServiceIDDoesNotDeleteUnlabeledService`
+
 ### Reassign imported TCP ports that conflict with existing NodePorts
 
 - Capability ID: `rainbond.gateway.reassign-conflicting-imported-tcp-port`
@@ -1884,6 +1922,16 @@
 - 代码路径: `api/handler/gateway_action.go`
 - 测试路径: `api/handler/gateway_action_test.go::TestReassignConflictingTCPRulePorts`
 
+### Reconcile stale TCP NodePort database rules after Kubernetes allocation
+
+- Capability ID: `rainbond.gateway.reconcile-stale-tcp-nodeport-rules`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `api/controller/apigateway.Struct.CreateTCPRoute`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteReconcilesStaleDatabaseRules`
+
 ### Reject duplicate TCP NodePort bindings
 
 - Capability ID: `rainbond.gateway.reject-duplicate-tcp-nodeport`
@@ -1893,6 +1941,36 @@
 - 业务入口: `TCP NodePort binding`
 - 代码路径: `db/mysql/dao/gateway.go`, `api/controller/apigateway/api_gateway_route.go`
 - 测试路径: `db/mysql/dao/gateway_test.go::TestTCPRuleDaoAddModelRejectsPortOwnedByAnotherRule`, `api/controller/apigateway/api_gateway_route_test.go::TestCreateTCPRouteRejectsExplicitPortOwnedByAnotherService`
+
+### Release only the requested owner when a TCP route Service is absent
+
+- Capability ID: `rainbond.gateway.release-absent-tcp-nodeport-owner`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `api/controller/apigateway.Struct.DeleteTCPRoute`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteAlreadyAbsentReleasesOnlyRequestedOwner`
+
+### Release only TCP NodePort rules captured before Service deletion
+
+- Capability ID: `rainbond.gateway.release-captured-tcp-nodeport-rules`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `api/controller/apigateway.Struct.DeleteTCPRoute`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestDeleteTCPRouteReleasesOnlyCapturedRuleIDs`
+
+### Reject out-of-range TCP NodePorts parsed from route names
+
+- Capability ID: `rainbond.gateway.validate-tcp-nodeport-route-name`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `package_function`
+- 业务入口: `api/controller/apigateway.nodePortFromTCPRouteName`
+- 代码路径: `api/controller/apigateway/api_gateway_route.go`
+- 测试路径: `api/controller/apigateway/api_gateway_route_test.go::TestNodePortFromTCPRouteNameValidatesRange`
 
 ### 为 Helm 历史输出格式化应用版本号
 
@@ -4773,6 +4851,16 @@
 - 业务入口: `worker/appm/store.getAppStatus`
 - 代码路径: `worker/appm/store/store.go`
 - 测试路径: `worker/appm/store/store_test.go::TestGetAppStatus`
+
+### 跳过 Rainbond 管理的 TCP 路由匿名端口预留
+
+- Capability ID: `rainbond.worker.appm.store.skip-managed-tcp-nodeport-reservation`
+- 状态: `active`
+- 测试类型: `regression`
+- 接口类型: `workflow`
+- 业务入口: `worker/appm/store.shouldTrackNodePortService`
+- 代码路径: `worker/appm/store/store.go`
+- 测试路径: `worker/appm/store/store_test.go::TestShouldTrackNodePortService`
 
 ### 在命名空间事件中同步受管命名空间的镜像拉取密钥
 

--- a/worker/appm/store/store.go
+++ b/worker/appm/store/store.go
@@ -395,6 +395,10 @@ func (a *appRuntimeStore) checkReplicasetWhetherDelete(app *v1.AppService, rs *a
 	}
 }
 
+func shouldTrackNodePortService(service *corev1.Service) bool {
+	return service.Labels["creator"] != "Rainbond" || service.Labels["tcp"] != "true" || service.Labels["outer"] != "true"
+}
+
 func (a *appRuntimeStore) OnAdd(obj interface{}, _ bool) {
 	if thirdComponent, ok := obj.(*v1alpha1.ThirdComponent); ok {
 		serviceID := thirdComponent.Labels["service_id"]
@@ -627,25 +631,27 @@ func (a *appRuntimeStore) OnAdd(obj interface{}, _ bool) {
 		}
 	}
 	if service, ok := obj.(*corev1.Service); ok {
-		for _, port := range service.Spec.Ports {
-			if port.NodePort != 0 {
-				nodePort := int(port.NodePort)
-				// 查询数据库是否存在该端口
-				exist, err := a.dbmanager.TCPRuleDao().GetTCPRuleByPort(nodePort)
-				if err != nil {
-					logrus.Errorf("get tcp rule by port failure: %v", err)
-				}
-				if exist == nil {
-					tcpRule := &model.TCPRule{
-						UUID:          "",
-						ServiceID:     "",
-						ContainerPort: int(port.Port),
-						IP:            "0.0.0.0",
-						Port:          int(port.NodePort),
-					}
-					err = a.dbmanager.TCPRuleDao().AddModel(tcpRule)
+		if shouldTrackNodePortService(service) {
+			for _, port := range service.Spec.Ports {
+				if port.NodePort != 0 {
+					nodePort := int(port.NodePort)
+					// 查询数据库是否存在该端口
+					exist, err := a.dbmanager.TCPRuleDao().GetTCPRuleByPort(nodePort)
 					if err != nil {
-						logrus.Errorf("add tcp rule failure: %v", err)
+						logrus.Errorf("get tcp rule by port failure: %v", err)
+					}
+					if exist == nil {
+						tcpRule := &model.TCPRule{
+							UUID:          "",
+							ServiceID:     "",
+							ContainerPort: int(port.Port),
+							IP:            "0.0.0.0",
+							Port:          int(port.NodePort),
+						}
+						err = a.dbmanager.TCPRuleDao().AddModel(tcpRule)
+						if err != nil {
+							logrus.Errorf("add tcp rule failure: %v", err)
+						}
 					}
 				}
 			}

--- a/worker/appm/store/store_test.go
+++ b/worker/appm/store/store_test.go
@@ -34,6 +34,91 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// capability_id: rainbond.worker.appm.store.skip-managed-tcp-nodeport-reservation
+func TestShouldTrackNodePortService(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name: "Rainbond-managed outer TCP route",
+			labels: map[string]string{
+				"creator": "Rainbond",
+				"tcp":     "true",
+				"outer":   "true",
+			},
+			want: false,
+		},
+		{
+			name: "ordinary NodePort service",
+			want: true,
+		},
+		{
+			name: "missing creator label",
+			labels: map[string]string{
+				"tcp":   "true",
+				"outer": "true",
+			},
+			want: true,
+		},
+		{
+			name: "missing tcp label",
+			labels: map[string]string{
+				"creator": "Rainbond",
+				"outer":   "true",
+			},
+			want: true,
+		},
+		{
+			name: "missing outer label",
+			labels: map[string]string{
+				"creator": "Rainbond",
+				"tcp":     "true",
+			},
+			want: true,
+		},
+		{
+			name: "different creator label",
+			labels: map[string]string{
+				"creator": "external",
+				"tcp":     "true",
+				"outer":   "true",
+			},
+			want: true,
+		},
+		{
+			name: "different tcp label",
+			labels: map[string]string{
+				"creator": "Rainbond",
+				"tcp":     "false",
+				"outer":   "true",
+			},
+			want: true,
+		},
+		{
+			name: "different outer label",
+			labels: map[string]string{
+				"creator": "Rainbond",
+				"tcp":     "true",
+				"outer":   "false",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Labels: tt.labels},
+				Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeNodePort},
+			}
+
+			assert.Equal(t, tt.want, shouldTrackNodePortService(service))
+		})
+	}
+}
+
 // capability_id: rainbond.worker.appm.store.aggregate-app-status
 func TestGetAppStatus(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- let Kubernetes arbitrate real NodePort conflicts instead of stale database rows
- atomically collapse owned and anonymous duplicates into one canonical TCP rule after successful Service create or update
- release only rule IDs captured before a UID-guarded Service deletion
- keep owner checks safe across same-name Service replacement and idempotent retries
- skip anonymous Worker reservations for Rainbond-managed external TCP route Services

No schema migration or manual database cleanup is required; stale rows are repaired lazily on successful allocation.

## Verification

- `go test ./api/controller/apigateway ./db/mysql/dao ./worker/appm/store`
- `go build ./...`
- `go vet ./...`
- `make check`
- capability manifest validation