### PR TITLE
fix: preserve existing buildkit configmap

### DIFF
--- a/builder/sources/buildkit_configmap_test.go
+++ b/builder/sources/buildkit_configmap_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2014-2026 Goodrain Co., Ltd.
+// RAINBOND, Application Management Platform
+
+package sources
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPrepareBuildKitTomlCMPreservesExistingConfigMap(t *testing.T) {
+	const (
+		namespace = "rbd-system"
+		name      = "goodrain-me"
+		manual    = "debug = false\n[registry.\"docker.io\"]\n  mirrors = [\"mirror.example.com\"]"
+	)
+	client := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string]string{"buildkittoml": manual},
+	})
+
+	if err := PrepareBuildKitTomlCM(context.Background(), client, namespace, name, "goodrain.me"); err != nil {
+		t.Fatalf("PrepareBuildKitTomlCM() error = %v", err)
+	}
+	for _, action := range client.Actions() {
+		if action.GetVerb() != "get" {
+			t.Fatalf("existing ConfigMap must be read-only, got Kubernetes action %q", action.GetVerb())
+		}
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get existing ConfigMap: %v", err)
+	}
+	if got := cm.Data["buildkittoml"]; got != manual {
+		t.Fatalf("existing buildkittoml was changed:\n got: %q\nwant: %q", got, manual)
+	}
+}
+
+func TestPrepareBuildKitTomlCMCreatesMissingConfigMap(t *testing.T) {
+	const (
+		namespace = "rbd-system"
+		name      = "goodrain-me"
+	)
+	client := fake.NewSimpleClientset()
+
+	if err := PrepareBuildKitTomlCM(context.Background(), client, namespace, name, "goodrain.me"); err != nil {
+		t.Fatalf("PrepareBuildKitTomlCM() error = %v", err)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get created ConfigMap: %v", err)
+	}
+	if cm.Data["buildkittoml"] == "" {
+		t.Fatal("created ConfigMap has empty buildkittoml")
+	}
+}

--- a/builder/sources/image.go
+++ b/builder/sources/image.go
@@ -1120,40 +1120,29 @@ func buildKitTomlContent(imageDomain string, mirrors []string) string {
 	return configStr
 }
 
-// PrepareBuildKitTomlCM ensures the buildkitd.toml ConfigMap exists and reflects
-// the current configuration. It creates the ConfigMap when absent and updates it
-// in place when the rendered content differs from the stored one, so registry
-// mirror changes take effect on the next build without manual cleanup.
+// PrepareBuildKitTomlCM creates the buildkitd.toml ConfigMap when it does not
+// already exist. Existing ConfigMaps are left untouched so operator changes are
+// preserved across builds.
 func PrepareBuildKitTomlCM(ctx context.Context, kubeClient kubernetes.Interface, namespace, buildKitTomlCMName, imageDomain string) error {
-	configStr := buildKitTomlContent(imageDomain, mergeMirrors(builder.REGISTRYMIRRORS, mirror.Default().Mirrors()))
-
-	buildKitTomlCM, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, buildKitTomlCMName, metav1.GetOptions{})
+	_, err := kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, buildKitTomlCMName, metav1.GetOptions{})
 	if err != nil && !k8serror.IsNotFound(err) {
 		return err
 	}
-	if k8serror.IsNotFound(err) {
-		buildKitTomlCM = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: buildKitTomlCMName,
-			},
-			Data: map[string]string{
-				"buildkittoml": configStr,
-			},
-		}
-		if _, err = kubeClient.CoreV1().ConfigMaps(namespace).Create(ctx, buildKitTomlCM, metav1.CreateOptions{}); err != nil {
-			return errors.Wrap(err, "create buildkittoml cm failure")
-		}
+	if err == nil {
 		return nil
 	}
-	if buildKitTomlCM.Data["buildkittoml"] == configStr {
-		return nil
+
+	configStr := buildKitTomlContent(imageDomain, mergeMirrors(builder.REGISTRYMIRRORS, mirror.Default().Mirrors()))
+	buildKitTomlCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: buildKitTomlCMName,
+		},
+		Data: map[string]string{
+			"buildkittoml": configStr,
+		},
 	}
-	if buildKitTomlCM.Data == nil {
-		buildKitTomlCM.Data = map[string]string{}
-	}
-	buildKitTomlCM.Data["buildkittoml"] = configStr
-	if _, err = kubeClient.CoreV1().ConfigMaps(namespace).Update(ctx, buildKitTomlCM, metav1.UpdateOptions{}); err != nil {
-		return errors.Wrap(err, "update buildkittoml cm failure")
+	if _, err = kubeClient.CoreV1().ConfigMaps(namespace).Create(ctx, buildKitTomlCM, metav1.CreateOptions{}); err != nil {
+		return errors.Wrap(err, "create buildkittoml cm failure")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- preserve an existing BuildKit ConfigMap during source builds
- create the ConfigMap only when it is missing
- add regression coverage for both existing and missing ConfigMaps

## Testing

- `go test -mod=mod ./builder/sources -count=1`
- `go build -mod=mod ./...`
- `go vet -mod=mod ./...`
- `make check`