### PR TITLE
feat: classify runnable Maven modules

### DIFF
--- a/builder/parser/code/multisvc/maven.go
+++ b/builder/parser/code/multisvc/maven.go
@@ -76,6 +76,7 @@ type module struct {
 	MavenCustomGoals string
 	MavenJavaOpts    string
 	Packaging        string
+	ModuleRole       string
 	BuiltArtifact    string
 }
 
@@ -112,8 +113,9 @@ func (m *maven) ListModules(path string) ([]*types.Service, error) {
 				cnames := strings.Split(name, "/")
 				return cnames[len(cnames)-1]
 			}(item.Name),
-			Packaging: item.Packaging,
-			Envs:      make(map[string]*types.Env),
+			Packaging:  item.Packaging,
+			ModuleRole: item.ModuleRole,
+			Envs:       make(map[string]*types.Env),
 		}
 		for _, env := range envs {
 			mo.Envs[env.Name] = &types.Env{Name: env.Name, Value: env.Value}
@@ -149,6 +151,7 @@ func listModules(prefix, topPref, finalName string) ([]*module, error) {
 				}
 				return "jar"
 			}(),
+			ModuleRole:       pom.moduleRole(),
 			MavenCustomOpts:  fmt.Sprintf("-DskipTests"),
 			MavenCustomGoals: fmt.Sprintf("clean dependency:list install -pl %s -am", name),
 			BuiltArtifact: func() string {
@@ -189,6 +192,26 @@ func parsePom(pomPath string) (*pom, error) {
 // checks if the pom has submodules.
 func (p *pom) hasSubmodules() bool {
 	return len(p.Modules) > 0
+}
+
+func (p *pom) hasSpringBootPlugin() bool {
+	if p.Build == nil || p.Build.Plugins == nil {
+		return false
+	}
+	for _, plugin := range p.Build.Plugins.Plugin {
+		if plugin != nil && plugin.ArtifactID == "spring-boot-maven-plugin" &&
+			(plugin.GroupID == "" || plugin.GroupID == "org.springframework.boot") {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *pom) moduleRole() string {
+	if p.Packaging == "war" || p.hasSpringBootPlugin() {
+		return types.ModuleRoleRunnable
+	}
+	return types.ModuleRolePossibleDependency
 }
 
 // TODO: read maven source code, learn how does maven get the final name

--- a/builder/parser/code/multisvc/maven_test.go
+++ b/builder/parser/code/multisvc/maven_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/goodrain/rainbond/builder/parser/types"
 )
 
 // capability_id: rainbond.maven.parse-pom
@@ -80,6 +82,8 @@ func TestMaven_ListModules(t *testing.T) {
     <module>rbd-api</module>
     <module>rbd-worker</module>
     <module>rbd-gateway</module>
+    <module>rbd-boot-default-group</module>
+    <module>rbd-fake-boot</module>
   </modules>
 </project>`
 	if err := os.WriteFile(filepath.Join(root, "pom.xml"), []byte(rootPom), 0o644); err != nil {
@@ -87,11 +91,15 @@ func TestMaven_ListModules(t *testing.T) {
 	}
 	modules := map[string]string{
 		"rbd-api": `<?xml version="1.0" encoding="UTF-8"?>
-<project><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>rbd-api</artifactId><version>1.0.0</version><packaging>jar</packaging></project>`,
+<project><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>rbd-api</artifactId><version>1.0.0</version><packaging>jar</packaging><build><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId></plugin></plugins></build></project>`,
 		"rbd-worker": `<?xml version="1.0" encoding="UTF-8"?>
 <project><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>rbd-worker</artifactId><version>1.0.0</version><packaging>jar</packaging></project>`,
 		"rbd-gateway": `<?xml version="1.0" encoding="UTF-8"?>
 <project><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>rbd-gateway</artifactId><version>1.0.0</version><packaging>war</packaging></project>`,
+		"rbd-boot-default-group": `<?xml version="1.0" encoding="UTF-8"?>
+<project><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>rbd-boot-default-group</artifactId><version>1.0.0</version><packaging>jar</packaging><build><plugins><plugin><artifactId>spring-boot-maven-plugin</artifactId></plugin></plugins></build></project>`,
+		"rbd-fake-boot": `<?xml version="1.0" encoding="UTF-8"?>
+<project><modelVersion>4.0.0</modelVersion><groupId>com.example</groupId><artifactId>rbd-fake-boot</artifactId><version>1.0.0</version><packaging>jar</packaging><build><plugins><plugin><groupId>com.example</groupId><artifactId>spring-boot-maven-plugin</artifactId></plugin></plugins></build></project>`,
 	}
 	for name, content := range modules {
 		dir := filepath.Join(root, name)
@@ -108,22 +116,35 @@ func TestMaven_ListModules(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(res) != 3 {
-		t.Fatalf("Expected 3 modules, but returned %d", len(res))
+	if len(res) != 5 {
+		t.Fatalf("Expected 5 modules, but returned %d", len(res))
 	}
-	names := []string{res[0].Name, res[1].Name, res[2].Name}
-	expected := map[string]string{
-		"rbd-api":     "jar",
-		"rbd-worker":  "jar",
-		"rbd-gateway": "war",
+	wantNames := []string{"rbd-api", "rbd-worker", "rbd-gateway", "rbd-boot-default-group", "rbd-fake-boot"}
+	for i, wantName := range wantNames {
+		if res[i].Name != wantName {
+			t.Fatalf("module order[%d] = %q, want %q", i, res[i].Name, wantName)
+		}
+	}
+	expected := map[string]struct {
+		packaging string
+		role      string
+	}{
+		"rbd-api":                {packaging: "jar", role: types.ModuleRoleRunnable},
+		"rbd-worker":             {packaging: "jar", role: types.ModuleRolePossibleDependency},
+		"rbd-gateway":            {packaging: "war", role: types.ModuleRoleRunnable},
+		"rbd-boot-default-group": {packaging: "jar", role: types.ModuleRoleRunnable},
+		"rbd-fake-boot":          {packaging: "jar", role: types.ModuleRolePossibleDependency},
 	}
 	for _, svc := range res {
-		packaging, ok := expected[svc.Name]
+		want, ok := expected[svc.Name]
 		if !ok {
-			t.Fatalf("unexpected module name %q in %v", svc.Name, names)
+			t.Fatalf("unexpected module name %q in %v", svc.Name, wantNames)
 		}
-		if svc.Packaging != packaging {
-			t.Fatalf("module %s packaging = %q, want %q", svc.Name, svc.Packaging, packaging)
+		if svc.Packaging != want.packaging {
+			t.Fatalf("module %s packaging = %q, want %q", svc.Name, svc.Packaging, want.packaging)
+		}
+		if svc.ModuleRole != want.role {
+			t.Fatalf("module %s role = %q, want %q", svc.Name, svc.ModuleRole, want.role)
 		}
 		if svc.Envs["BUILD_MAVEN_CUSTOM_GOALS"] == nil {
 			t.Fatalf("module %s missing BUILD_MAVEN_CUSTOM_GOALS", svc.Name)
@@ -137,7 +158,7 @@ func TestMaven_ListModules(t *testing.T) {
 		if svc.Envs["BUILD_MAVEN_BUILT_ARTIFACT"] == nil {
 			t.Fatalf("module %s missing BUILD_MAVEN_BUILT_ARTIFACT", svc.Name)
 		}
-		wantArtifact := svc.Name + "/target/" + svc.Name + "-*." + packaging
+		wantArtifact := svc.Name + "/target/" + svc.Name + "-*." + want.packaging
 		if got := svc.Envs["BUILD_MAVEN_BUILT_ARTIFACT"].Value; got != wantArtifact {
 			t.Fatalf("module %s BUILD_MAVEN_BUILT_ARTIFACT = %q, want %q", svc.Name, got, wantArtifact)
 		}

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -198,10 +198,11 @@ type ServiceInfo struct {
 	//For third party services
 	Endpoints []*discovery.Endpoint `json:"endpoints,omitempty"`
 	//os type,default linux
-	OS   string `json:"os"`
-	Name string `json:"name,omitempty"` // module name
-	Cname string `json:"cname,omitempty"` // service cname
-	Packaging string `json:"packaging,omitempty"`
+	OS         string `json:"os"`
+	Name       string `json:"name,omitempty"`  // module name
+	Cname      string `json:"cname,omitempty"` // service cname
+	Packaging  string `json:"packaging,omitempty"`
+	ModuleRole string `json:"module_role,omitempty"`
 	// Dockerfile 文件列表，相对于代码根目录的路径
 	Dockerfiles []string `json:"dockerfiles,omitempty"`
 

--- a/builder/parser/source_code.go
+++ b/builder/parser/source_code.go
@@ -798,6 +798,7 @@ func (d *SourceCodeParse) GetServiceInfo() []ServiceInfo {
 			info.Name = svc.Name
 			info.Cname = svc.Cname
 			info.Packaging = svc.Packaging
+			info.ModuleRole = svc.ModuleRole
 			for i := range svc.Envs {
 				info.Envs = append(info.Envs, *svc.Envs[i])
 			}

--- a/builder/parser/source_code_args_test.go
+++ b/builder/parser/source_code_args_test.go
@@ -116,8 +116,8 @@ func TestGetServiceInfo_MultiModulesPreserveDockerfileDetection(t *testing.T) {
 		dockerfiles: []string{"Dockerfile"},
 		isMulti:     true,
 		services: []*types.Service{
-			{Name: "service-a", Cname: "service-a", Packaging: "jar"},
-			{Name: "service-b", Cname: "service-b", Packaging: "jar"},
+			{Name: "service-a", Cname: "service-a", Packaging: "jar", ModuleRole: types.ModuleRoleRunnable},
+			{Name: "service-b", Cname: "service-b", Packaging: "jar", ModuleRole: types.ModuleRolePossibleDependency},
 		},
 	}
 
@@ -125,12 +125,15 @@ func TestGetServiceInfo_MultiModulesPreserveDockerfileDetection(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("GetServiceInfo() returned %d services, want 2", len(got))
 	}
-	for _, info := range got {
+	for idx, info := range got {
 		if info.Lang != code.Lang("dockerfile,Java-maven") {
 			t.Fatalf("service %q language = %q, want dockerfile,Java-maven", info.Name, info.Lang)
 		}
 		if len(info.Dockerfiles) != 1 || info.Dockerfiles[0] != "Dockerfile" {
 			t.Fatalf("service %q Dockerfiles = %v, want [Dockerfile]", info.Name, info.Dockerfiles)
+		}
+		if info.ModuleRole != d.services[idx].ModuleRole {
+			t.Fatalf("service %q module role = %q, want %q", info.Name, info.ModuleRole, d.services[idx].ModuleRole)
 		}
 	}
 }

--- a/builder/parser/types/types.go
+++ b/builder/parser/types/types.go
@@ -18,14 +18,22 @@
 
 package types
 
+const (
+	// ModuleRoleRunnable identifies a module that can be deployed directly.
+	ModuleRoleRunnable = "runnable"
+	// ModuleRolePossibleDependency identifies a module that may only provide dependencies.
+	ModuleRolePossibleDependency = "possible_dependency"
+)
+
 // Service represents a module in a multi-module project.
 type Service struct {
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`  // module name
-	Cname     string          `json:"cname"` // service cname
-	Packaging string          `json:"packaging"`
-	Envs      map[string]*Env `json:"envs,omitempty"`
-	Ports     map[int]*Port   `json:"ports,omitempty"`
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`  // module name
+	Cname      string          `json:"cname"` // service cname
+	Packaging  string          `json:"packaging"`
+	ModuleRole string          `json:"module_role,omitempty"`
+	Envs       map[string]*Env `json:"envs,omitempty"`
+	Ports      map[int]*Port   `json:"ports,omitempty"`
 }
 
 // Port -


### PR DESCRIPTION
## Summary

- classify Maven multi-module entries as runnable or possible dependency modules
- recognize WAR modules and Spring Boot Maven plugin modules as runnable
- expose the optional module_role field without changing existing build command or artifact detection

## Verification

- go test ./builder/parser/...
- go build ./...
- go vet ./...
- make check

## Companion PRs

- Console: https://github.com/goodrain/rainbond-console/pull/2119
- UI: https://github.com/goodrain/rainbond-ui/pull/1920