### PR TITLE
refactor: simplify Maven multi-module detection

### DIFF
--- a/builder/build/cnb/lang_java_test.go
+++ b/builder/build/cnb/lang_java_test.go
@@ -257,8 +257,8 @@ func TestJavaLanguageConfigAutoDetectsUniqueMavenModule(t *testing.T) {
 	if annotations["cnb-bp-maven-built-module"] != "service-a" {
 		t.Fatalf("expected unique maven module service-a, got %q", annotations["cnb-bp-maven-built-module"])
 	}
-	if annotations["cnb-bp-maven-built-artifact"] != "service-a/target/service-a-*.jar" {
-		t.Fatalf("expected unique maven artifact, got %q", annotations["cnb-bp-maven-built-artifact"])
+	if artifact := annotations["cnb-bp-maven-built-artifact"]; artifact != "" {
+		t.Fatalf("expected Maven auto-detection not to set a built artifact, got %q", artifact)
 	}
 }
 

--- a/builder/parser/code/multisvc/maven.go
+++ b/builder/parser/code/multisvc/maven.go
@@ -20,7 +20,6 @@ package multi
 
 import (
 	"encoding/xml"
-	"fmt"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -29,24 +28,6 @@ import (
 	"github.com/goodrain/rainbond/util"
 	"github.com/sirupsen/logrus"
 )
-
-// Build represents build in pom.xml
-type Build struct {
-	FinalName string   `xml:"finalName"`
-	Plugins   *Plugins `xml:"plugins"`
-}
-
-// Plugins represents plugins in pom.xml
-type Plugins struct {
-	Plugin []*Plugin `xml:"plugin"`
-}
-
-// Plugin represents plugin in pom.xml
-type Plugin struct {
-	GroupID    string `xml:"groupId"`
-	ArtifactID string `xml:"artifactId"`
-	FinalName  string `xml:"configuration>finalName"`
-}
 
 // maven is an implementation of MutilModuler.
 type maven struct {
@@ -65,47 +46,23 @@ type pom struct {
 	Version    string   `xml:"version"`
 	Packaging  string   `xml:"packaging"`
 	Modules    []string `xml:"modules>module"`
-	Build      *Build   `xml:"build"`
 }
 
 // module represents a maven module
 type module struct {
-	ID               string
-	Name             string
-	MavenCustomOpts  string
-	MavenCustomGoals string
-	MavenJavaOpts    string
-	Packaging        string
-	ModuleRole       string
-	BuiltArtifact    string
+	ID        string
+	Name      string
+	Packaging string
 }
 
 // ListModules lists all maven modules from pom.xml
 func (m *maven) ListModules(path string) ([]*types.Service, error) {
-	modules, err := listModules(path, strings.TrimRight(path, "/")+"/", "")
+	modules, err := listModules(path, strings.TrimRight(path, "/")+"/")
 	if err != nil {
 		return nil, err
 	}
 	var res []*types.Service
 	for _, item := range modules {
-		envs := []*types.Env{
-			{
-				Name:  "BUILD_MAVEN_CUSTOM_OPTS",
-				Value: item.MavenCustomOpts,
-			},
-			{
-				Name:  "BUILD_MAVEN_CUSTOM_GOALS",
-				Value: item.MavenCustomGoals,
-			},
-			{
-				Name:  "BUILD_MAVEN_BUILT_MODULE",
-				Value: item.Name,
-			},
-			{
-				Name:  "BUILD_MAVEN_BUILT_ARTIFACT",
-				Value: item.BuiltArtifact,
-			},
-		}
 		mo := &types.Service{
 			ID:   item.ID,
 			Name: item.Name,
@@ -113,33 +70,29 @@ func (m *maven) ListModules(path string) ([]*types.Service, error) {
 				cnames := strings.Split(name, "/")
 				return cnames[len(cnames)-1]
 			}(item.Name),
-			Packaging:  item.Packaging,
-			ModuleRole: item.ModuleRole,
-			Envs:       make(map[string]*types.Env),
-		}
-		for _, env := range envs {
-			mo.Envs[env.Name] = &types.Env{Name: env.Name, Value: env.Value}
+			Packaging: item.Packaging,
+			Envs: map[string]*types.Env{
+				"BUILD_MAVEN_BUILT_MODULE": {
+					Name:  "BUILD_MAVEN_BUILT_MODULE",
+					Value: item.Name,
+				},
+			},
 		}
 		res = append(res, mo)
 	}
 	return res, nil
 }
 
-func listModules(prefix, topPref, finalName string) ([]*module, error) {
+func listModules(prefix, topPref string) ([]*module, error) {
 	pomPath := path.Join(prefix, "pom.xml")
 	pom, err := parsePom(pomPath)
 	if err != nil {
 		return nil, err
 	}
 
-	if pom.Build != nil && pom.Build.FinalName != "" {
-		finalName = pom.Build.FinalName
-	}
-
 	var modules []*module // module names
 	// recursive end condition
 	if pom.isValidModule() {
-		filename := pom.getExecuteFilename(finalName)
 		// full module name. eg: foobar/rbd-worker
 		name := strings.Replace(prefix, topPref, "", 1)
 		mo := &module{
@@ -151,19 +104,13 @@ func listModules(prefix, topPref, finalName string) ([]*module, error) {
 				}
 				return "jar"
 			}(),
-			ModuleRole:       pom.moduleRole(),
-			MavenCustomOpts:  fmt.Sprintf("-DskipTests"),
-			MavenCustomGoals: fmt.Sprintf("clean dependency:list install -pl %s -am", name),
-			BuiltArtifact: func() string {
-				return fmt.Sprintf("%s/target/%s", name, filename)
-			}(),
 		}
 		return []*module{mo}, nil
 	}
 
 	for _, name := range pom.Modules {
 		// submodule names
-		submodules, err := listModules(path.Join(prefix, name), topPref, finalName)
+		submodules, err := listModules(path.Join(prefix, name), topPref)
 		if err != nil {
 			logrus.Warningf("Prefix: %s; error getting module names: %v",
 				path.Join(prefix, name), err)
@@ -192,66 +139,6 @@ func parsePom(pomPath string) (*pom, error) {
 // checks if the pom has submodules.
 func (p *pom) hasSubmodules() bool {
 	return len(p.Modules) > 0
-}
-
-func (p *pom) hasSpringBootPlugin() bool {
-	if p.Build == nil || p.Build.Plugins == nil {
-		return false
-	}
-	for _, plugin := range p.Build.Plugins.Plugin {
-		if plugin != nil && plugin.ArtifactID == "spring-boot-maven-plugin" &&
-			(plugin.GroupID == "" || plugin.GroupID == "org.springframework.boot") {
-			return true
-		}
-	}
-	return false
-}
-
-func (p *pom) moduleRole() string {
-	if p.Packaging == "war" || p.hasSpringBootPlugin() {
-		return types.ModuleRoleRunnable
-	}
-	return types.ModuleRolePossibleDependency
-}
-
-// TODO: read maven source code, learn how does maven get the final name
-func (p *pom) getExecuteFilename(finalName string) string {
-	// default finalName
-	name := p.ArtifactID + "-*"
-	if p.Build != nil {
-		// the finalName in the plugin has a higher priority than in the build.
-		if p.Build.FinalName != "" {
-			finalName = p.Build.FinalName
-		}
-		if p.Build.Plugins != nil && p.Build.Plugins.Plugin != nil && len(p.Build.Plugins.Plugin) > 0 {
-			for _, plugin := range p.Build.Plugins.Plugin {
-				if plugin.ArtifactID == "spring-boot-maven-plugin" && plugin.GroupID == "org.springframework.boot" &&
-					plugin.FinalName != "" {
-					finalName = plugin.FinalName
-					break
-				}
-			}
-		}
-	}
-	if finalName == "${project.name}" {
-		name = p.ArtifactID
-		if p.Name != "" {
-			name = p.Name
-		}
-	} else if finalName == "${project.artifactId}" {
-		name = p.ArtifactID
-	} else if strings.HasPrefix(finalName, "") && strings.HasSuffix(finalName, "}") {
-		name = "*"
-	} else if finalName != "" {
-		name = finalName
-	}
-	suffix := func() string {
-		if p.Packaging == "" {
-			return "jar"
-		}
-		return p.Packaging
-	}
-	return name + "." + suffix()
 }
 
 func (p *pom) isValidModule() bool {

--- a/builder/parser/code/multisvc/maven_test.go
+++ b/builder/parser/code/multisvc/maven_test.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/goodrain/rainbond/builder/parser/types"
 )
 
 // capability_id: rainbond.maven.parse-pom
@@ -125,45 +123,29 @@ func TestMaven_ListModules(t *testing.T) {
 			t.Fatalf("module order[%d] = %q, want %q", i, res[i].Name, wantName)
 		}
 	}
-	expected := map[string]struct {
-		packaging string
-		role      string
-	}{
-		"rbd-api":                {packaging: "jar", role: types.ModuleRoleRunnable},
-		"rbd-worker":             {packaging: "jar", role: types.ModuleRolePossibleDependency},
-		"rbd-gateway":            {packaging: "war", role: types.ModuleRoleRunnable},
-		"rbd-boot-default-group": {packaging: "jar", role: types.ModuleRoleRunnable},
-		"rbd-fake-boot":          {packaging: "jar", role: types.ModuleRolePossibleDependency},
+	expectedPackaging := map[string]string{
+		"rbd-api":                "jar",
+		"rbd-worker":             "jar",
+		"rbd-gateway":            "war",
+		"rbd-boot-default-group": "jar",
+		"rbd-fake-boot":          "jar",
 	}
 	for _, svc := range res {
-		want, ok := expected[svc.Name]
+		wantPackaging, ok := expectedPackaging[svc.Name]
 		if !ok {
 			t.Fatalf("unexpected module name %q in %v", svc.Name, wantNames)
 		}
-		if svc.Packaging != want.packaging {
-			t.Fatalf("module %s packaging = %q, want %q", svc.Name, svc.Packaging, want.packaging)
+		if svc.Packaging != wantPackaging {
+			t.Fatalf("module %s packaging = %q, want %q", svc.Name, svc.Packaging, wantPackaging)
 		}
-		if svc.ModuleRole != want.role {
-			t.Fatalf("module %s role = %q, want %q", svc.Name, svc.ModuleRole, want.role)
-		}
-		if svc.Envs["BUILD_MAVEN_CUSTOM_GOALS"] == nil {
-			t.Fatalf("module %s missing BUILD_MAVEN_CUSTOM_GOALS", svc.Name)
+		if len(svc.Envs) != 1 {
+			t.Fatalf("module %s env count = %d, want only BUILD_MAVEN_BUILT_MODULE: %#v", svc.Name, len(svc.Envs), svc.Envs)
 		}
 		if svc.Envs["BUILD_MAVEN_BUILT_MODULE"] == nil {
 			t.Fatalf("module %s missing BUILD_MAVEN_BUILT_MODULE", svc.Name)
 		}
 		if svc.Envs["BUILD_MAVEN_BUILT_MODULE"].Value != svc.Name {
 			t.Fatalf("module %s BUILD_MAVEN_BUILT_MODULE = %q, want %q", svc.Name, svc.Envs["BUILD_MAVEN_BUILT_MODULE"].Value, svc.Name)
-		}
-		if svc.Envs["BUILD_MAVEN_BUILT_ARTIFACT"] == nil {
-			t.Fatalf("module %s missing BUILD_MAVEN_BUILT_ARTIFACT", svc.Name)
-		}
-		wantArtifact := svc.Name + "/target/" + svc.Name + "-*." + want.packaging
-		if got := svc.Envs["BUILD_MAVEN_BUILT_ARTIFACT"].Value; got != wantArtifact {
-			t.Fatalf("module %s BUILD_MAVEN_BUILT_ARTIFACT = %q, want %q", svc.Name, got, wantArtifact)
-		}
-		if svc.Packaging == "war" && svc.Envs["BUILD_PROCFILE"] != nil && svc.Envs["BUILD_PROCFILE"].Value == "" {
-			t.Fatalf("module %s missing BUILD_PROCFILE value", svc.Name)
 		}
 	}
 }

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -198,11 +198,10 @@ type ServiceInfo struct {
 	//For third party services
 	Endpoints []*discovery.Endpoint `json:"endpoints,omitempty"`
 	//os type,default linux
-	OS         string `json:"os"`
-	Name       string `json:"name,omitempty"`  // module name
-	Cname      string `json:"cname,omitempty"` // service cname
-	Packaging  string `json:"packaging,omitempty"`
-	ModuleRole string `json:"module_role,omitempty"`
+	OS        string `json:"os"`
+	Name      string `json:"name,omitempty"`  // module name
+	Cname     string `json:"cname,omitempty"` // service cname
+	Packaging string `json:"packaging,omitempty"`
 	// Dockerfile 文件列表，相对于代码根目录的路径
 	Dockerfiles []string `json:"dockerfiles,omitempty"`
 

--- a/builder/parser/source_code.go
+++ b/builder/parser/source_code.go
@@ -798,7 +798,6 @@ func (d *SourceCodeParse) GetServiceInfo() []ServiceInfo {
 			info.Name = svc.Name
 			info.Cname = svc.Cname
 			info.Packaging = svc.Packaging
-			info.ModuleRole = svc.ModuleRole
 			for i := range svc.Envs {
 				info.Envs = append(info.Envs, *svc.Envs[i])
 			}

--- a/builder/parser/source_code_args_test.go
+++ b/builder/parser/source_code_args_test.go
@@ -116,8 +116,8 @@ func TestGetServiceInfo_MultiModulesPreserveDockerfileDetection(t *testing.T) {
 		dockerfiles: []string{"Dockerfile"},
 		isMulti:     true,
 		services: []*types.Service{
-			{Name: "service-a", Cname: "service-a", Packaging: "jar", ModuleRole: types.ModuleRoleRunnable},
-			{Name: "service-b", Cname: "service-b", Packaging: "jar", ModuleRole: types.ModuleRolePossibleDependency},
+			{Name: "service-a", Cname: "service-a", Packaging: "jar"},
+			{Name: "service-b", Cname: "service-b", Packaging: "jar"},
 		},
 	}
 
@@ -125,15 +125,12 @@ func TestGetServiceInfo_MultiModulesPreserveDockerfileDetection(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("GetServiceInfo() returned %d services, want 2", len(got))
 	}
-	for idx, info := range got {
+	for _, info := range got {
 		if info.Lang != code.Lang("dockerfile,Java-maven") {
 			t.Fatalf("service %q language = %q, want dockerfile,Java-maven", info.Name, info.Lang)
 		}
 		if len(info.Dockerfiles) != 1 || info.Dockerfiles[0] != "Dockerfile" {
 			t.Fatalf("service %q Dockerfiles = %v, want [Dockerfile]", info.Name, info.Dockerfiles)
-		}
-		if info.ModuleRole != d.services[idx].ModuleRole {
-			t.Fatalf("service %q module role = %q, want %q", info.Name, info.ModuleRole, d.services[idx].ModuleRole)
 		}
 	}
 }

--- a/builder/parser/types/types.go
+++ b/builder/parser/types/types.go
@@ -18,22 +18,14 @@
 
 package types
 
-const (
-	// ModuleRoleRunnable identifies a module that can be deployed directly.
-	ModuleRoleRunnable = "runnable"
-	// ModuleRolePossibleDependency identifies a module that may only provide dependencies.
-	ModuleRolePossibleDependency = "possible_dependency"
-)
-
 // Service represents a module in a multi-module project.
 type Service struct {
-	ID         string          `json:"id"`
-	Name       string          `json:"name"`  // module name
-	Cname      string          `json:"cname"` // service cname
-	Packaging  string          `json:"packaging"`
-	ModuleRole string          `json:"module_role,omitempty"`
-	Envs       map[string]*Env `json:"envs,omitempty"`
-	Ports      map[int]*Port   `json:"ports,omitempty"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`  // module name
+	Cname     string          `json:"cname"` // service cname
+	Packaging string          `json:"packaging"`
+	Envs      map[string]*Env `json:"envs,omitempty"`
+	Ports     map[int]*Port   `json:"ports,omitempty"`
 }
 
 // Port -


### PR DESCRIPTION
## Summary

- preserve Maven POM module order and remove module-role classification
- emit only BUILD_MAVEN_BUILT_MODULE for each detected module
- stop auto-detecting Maven goals, options, and target artifacts

## Related PRs

- goodrain/rainbond-console#2121
- goodrain/rainbond-ui#1921

## Validation

- go test -mod=mod ./... -count=1
- go build -mod=mod ./...
- go vet -mod=mod ./...
- make check